### PR TITLE
Fix CMake to include vtk files.

### DIFF
--- a/Code/Source/svFSI/CMakeLists.txt
+++ b/Code/Source/svFSI/CMakeLists.txt
@@ -72,7 +72,7 @@ find_package(LAPACK REQUIRED)
 #   -iframe is valid for C/C++/ObjC/ObjC++ but not for Fortran
 #
 find_package(VTK REQUIRED)
-#include(${VTK_USE_FILE})
+include(${VTK_USE_FILE})
 
 set(lib ${SV_LIB_SVFSI_NAME})
 


### PR DESCRIPTION
The CMake command `include(${VTK_USE_FILE})` was commented out for some reason. 