### PR TITLE
Disable Array and Vector index checking.

### DIFF
--- a/Code/Source/svFSI/Array.h
+++ b/Code/Source/svFSI/Array.h
@@ -15,7 +15,7 @@
 
 // If set then check Array indexes.
 //
-#define Array_check_enabled
+//#define Array_check_enabled
 
 //-------
 // Array 

--- a/Code/Source/svFSI/Vector.h
+++ b/Code/Source/svFSI/Vector.h
@@ -9,7 +9,7 @@
 
 std::string build_file_prefix(const std::string& label);
 
-#define Vector_check_enabled
+//#define Vector_check_enabled
 
 //-------
 // Vector 


### PR DESCRIPTION
Array and Vector index checking slows down execution significantly, only needed during code development.
