### PR TITLE
Actions macos build fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,6 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: | 
           brew install cmake vtk openblas lapack mesa open-mpi qt
-          #brew link --force qt5
-          #brew link --overwrite qt@5
           brew install lcov
           sudo ln -s /usr/local/opt/qt5/mkspecs /usr/local/mkspecs
           sudo ln -s /usr/local/opt/qt5/plugins /usr/local/plugins


### PR DESCRIPTION
GitHub Actions build is failing for MacOS 12 because of some YAML statements for Qt https://github.com/SimVascular/svFSIplus/issues/89.