### PR TITLE
Test different LS with the same reference solution

### DIFF
--- a/tests/cases/diffusion_line_source/result_002.vtu
+++ b/tests/cases/diffusion_line_source/result_002.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5908dabbd3a7e4985f483f42c1c7096b57969e48bfbd3aeac5a01631d72d93eb
+size 246243

--- a/tests/cases/diffusion_line_source/result_020.vtu
+++ b/tests/cases/diffusion_line_source/result_020.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:116adb1b3149bb0b52390bd2b176d0ed7550990d7f875f634e4e88baf4a01a68
-size 283877

--- a/tests/cases/diffusion_line_source/svFSI_BICG.xml
+++ b/tests/cases/diffusion_line_source/svFSI_BICG.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<svFSIFile version="0.1">
+
+<GeneralSimulationParameters>
+
+  <Continue_previous_simulation> false </Continue_previous_simulation>
+  <Number_of_spatial_dimensions> 2 </Number_of_spatial_dimensions> 
+  <Number_of_time_steps> 2 </Number_of_time_steps> 
+  <Time_step_size> 0.01 </Time_step_size> 
+  <Spectral_radius_of_infinite_time_step> 0.50 </Spectral_radius_of_infinite_time_step> 
+  <Searched_file_name_to_trigger_stop> STOP_SIM </Searched_file_name_to_trigger_stop> 
+
+  <Save_results_to_VTK_format> 1 </Save_results_to_VTK_format> 
+  <Name_prefix_of_saved_VTK_files> result </Name_prefix_of_saved_VTK_files> 
+  <Increment_in_saving_VTK_files> 2 </Increment_in_saving_VTK_files> 
+  <Start_saving_after_time_step> 1 </Start_saving_after_time_step> 
+
+  <Increment_in_saving_restart_files> 100 </Increment_in_saving_restart_files> 
+  <Convert_BIN_to_VTK_format> 0 </Convert_BIN_to_VTK_format> 
+
+  <Verbose> 1 </Verbose> 
+  <Warning> 0 </Warning> 
+  <Debug> 0 </Debug> 
+
+</GeneralSimulationParameters>
+
+<Add_mesh name="msh" > 
+
+  <Mesh_file_path> mesh/mesh-complete.mesh.vtu </Mesh_file_path>
+
+  <Add_face name="left">
+      <Face_file_path> mesh/mesh-surfaces/left.vtp </Face_file_path>
+  </Add_face>
+
+  <Add_face name="right">
+      <Face_file_path> mesh/mesh-surfaces/right.vtp </Face_file_path>
+  </Add_face>
+
+  <Add_face name="bottom">
+      <Face_file_path> mesh/mesh-surfaces/bottom.vtp </Face_file_path>
+  </Add_face>
+
+  <Add_face name="top">
+      <Face_file_path> mesh/mesh-surfaces/bottom.vtp </Face_file_path>
+  </Add_face>
+
+</Add_mesh>
+
+<Add_equation type="heatS" > 
+   <Coupled> true </Coupled>
+   <Min_iterations> 1 </Min_iterations>  
+   <Max_iterations> 5 </Max_iterations> 
+   <Tolerance> 1e-6 </Tolerance> 
+
+   <Conductivity> 1.0 </Conductivity> 
+   <Source_term> 0.0 </Source_term> 
+   <Density> 0.0 </Density> 
+
+   <Output type="Spatial" >
+     <Temperature> true </Temperature>
+     <Heat_flux> true </Heat_flux>
+   </Output>
+
+   <LS type="BICG" >
+      <Max_iterations> 100 </Max_iterations>
+      <Tolerance> 1e-6 </Tolerance>
+   </LS>
+
+   <Add_BC name="left" > 
+      <Type> Dir </Type> 
+      <Value> 10.0 </Value> 
+      <Zero_out_perimeter> false </Zero_out_perimeter> 
+   </Add_BC> 
+
+   <Add_BC name="right" > 
+      <Type> Dir </Type> 
+      <Value> 0.0 </Value> 
+      <Zero_out_perimeter> true </Zero_out_perimeter> 
+   </Add_BC> 
+
+</Add_equation>
+
+</svFSIFile>
+
+

--- a/tests/cases/diffusion_line_source/svFSI_CG.xml
+++ b/tests/cases/diffusion_line_source/svFSI_CG.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<svFSIFile version="0.1">
+
+<GeneralSimulationParameters>
+
+  <Continue_previous_simulation> false </Continue_previous_simulation>
+  <Number_of_spatial_dimensions> 2 </Number_of_spatial_dimensions> 
+  <Number_of_time_steps> 2 </Number_of_time_steps> 
+  <Time_step_size> 0.01 </Time_step_size> 
+  <Spectral_radius_of_infinite_time_step> 0.50 </Spectral_radius_of_infinite_time_step> 
+  <Searched_file_name_to_trigger_stop> STOP_SIM </Searched_file_name_to_trigger_stop> 
+
+  <Save_results_to_VTK_format> 1 </Save_results_to_VTK_format> 
+  <Name_prefix_of_saved_VTK_files> result </Name_prefix_of_saved_VTK_files> 
+  <Increment_in_saving_VTK_files> 2 </Increment_in_saving_VTK_files> 
+  <Start_saving_after_time_step> 1 </Start_saving_after_time_step> 
+
+  <Increment_in_saving_restart_files> 100 </Increment_in_saving_restart_files> 
+  <Convert_BIN_to_VTK_format> 0 </Convert_BIN_to_VTK_format> 
+
+  <Verbose> 1 </Verbose> 
+  <Warning> 0 </Warning> 
+  <Debug> 0 </Debug> 
+
+</GeneralSimulationParameters>
+
+<Add_mesh name="msh" > 
+
+  <Mesh_file_path> mesh/mesh-complete.mesh.vtu </Mesh_file_path>
+
+  <Add_face name="left">
+      <Face_file_path> mesh/mesh-surfaces/left.vtp </Face_file_path>
+  </Add_face>
+
+  <Add_face name="right">
+      <Face_file_path> mesh/mesh-surfaces/right.vtp </Face_file_path>
+  </Add_face>
+
+  <Add_face name="bottom">
+      <Face_file_path> mesh/mesh-surfaces/bottom.vtp </Face_file_path>
+  </Add_face>
+
+  <Add_face name="top">
+      <Face_file_path> mesh/mesh-surfaces/bottom.vtp </Face_file_path>
+  </Add_face>
+
+</Add_mesh>
+
+<Add_equation type="heatS" > 
+   <Coupled> true </Coupled>
+   <Min_iterations> 1 </Min_iterations>  
+   <Max_iterations> 5 </Max_iterations> 
+   <Tolerance> 1e-6 </Tolerance> 
+
+   <Conductivity> 1.0 </Conductivity> 
+   <Source_term> 0.0 </Source_term> 
+   <Density> 0.0 </Density> 
+
+   <Output type="Spatial" >
+     <Temperature> true </Temperature>
+     <Heat_flux> true </Heat_flux>
+   </Output>
+
+   <LS type="CG" >
+      <Preconditioner> RCS </Preconditioner> 
+      <Tolerance> 1e-6 </Tolerance>
+   </LS>
+
+   <Add_BC name="left" > 
+      <Type> Dir </Type> 
+      <Value> 10.0 </Value> 
+      <Zero_out_perimeter> false </Zero_out_perimeter> 
+   </Add_BC> 
+
+   <Add_BC name="right" > 
+      <Type> Dir </Type> 
+      <Value> 0.0 </Value> 
+      <Zero_out_perimeter> true </Zero_out_perimeter> 
+   </Add_BC> 
+
+</Add_equation>
+
+</svFSIFile>
+
+

--- a/tests/cases/diffusion_line_source/svFSI_GMRES.xml
+++ b/tests/cases/diffusion_line_source/svFSI_GMRES.xml
@@ -5,14 +5,14 @@
 
   <Continue_previous_simulation> false </Continue_previous_simulation>
   <Number_of_spatial_dimensions> 2 </Number_of_spatial_dimensions> 
-  <Number_of_time_steps> 20 </Number_of_time_steps> 
+  <Number_of_time_steps> 2 </Number_of_time_steps> 
   <Time_step_size> 0.01 </Time_step_size> 
   <Spectral_radius_of_infinite_time_step> 0.50 </Spectral_radius_of_infinite_time_step> 
   <Searched_file_name_to_trigger_stop> STOP_SIM </Searched_file_name_to_trigger_stop> 
 
   <Save_results_to_VTK_format> 1 </Save_results_to_VTK_format> 
   <Name_prefix_of_saved_VTK_files> result </Name_prefix_of_saved_VTK_files> 
-  <Increment_in_saving_VTK_files> 20 </Increment_in_saving_VTK_files> 
+  <Increment_in_saving_VTK_files> 2 </Increment_in_saving_VTK_files> 
   <Start_saving_after_time_step> 1 </Start_saving_after_time_step> 
 
   <Increment_in_saving_restart_files> 100 </Increment_in_saving_restart_files> 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -111,13 +111,12 @@ def test_niederer_benchmark_ECGs_quadrature(confs_ecgs, n_proc):
         assert abs((ecg_trace.iloc[-1, 1] - confs_ecgs[jj + 1]) / confs_ecgs[jj + 1]) < RTOL['ECG'], \
                "Results in field ecglead_" + str(jj + 1) + ".txt differ by more than rtol=" + str(RTOL['ECG']) + " for test case " + confs_ecgs[0] 
 
-
+@pytest.mark.parametrize("name_inp", ["svFSI_CG.xml", "svFSI_BICG.xml", "svFSI_GMRES.xml"])
 @pytest.mark.parametrize("n_proc", procs)
-def test_diffusion_line_source(n_proc):
+def test_diffusion_line_source(name_inp, n_proc):
     folder = os.path.join("cases", "diffusion_line_source")
     field = ["Temperature"]
-    t_max = 20
-    name_inp = "svFSI.xml"
+    t_max = 2
     name_ref = "result_" + str(t_max).zfill(3) + ".vtu"
     run_with_reference(folder, name_inp, name_ref, field, t_max, n_proc)
 


### PR DESCRIPTION
With reference to #95, this MR adds a test assuring that the output of different linear solvers (CG, BICG and GMRES) matches the same reference solution (generated with GMRES) for the `diffusion_line_source`.
@mrp089, it's all yours (again)!