### PR TITLE
Fix deployment of Doxygen documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ jobs:
           name: documentation
           path: Documentation/build/html
       - name: Deploy documentation
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix for #97. The branch `gh-pages` wasn't deployed because the workflow was looking for a `master` branch, but `svFSI+` has a `main` branch.