### PR TITLE
Add processing the Holzapfel material model.

### DIFF
--- a/Code/Source/svFSI/Parameters.cpp
+++ b/Code/Source/svFSI/Parameters.cpp
@@ -461,6 +461,7 @@ const std::string ConstitutiveModelParameters::xml_element_name_ = "Constitutive
 // [TODO] Should use the types defined in consts.h.
 const std::string ConstitutiveModelParameters::GUCCIONE_MODEL = "Guccione";
 const std::string ConstitutiveModelParameters::HGO_MODEL = "HGO";
+const std::string ConstitutiveModelParameters::HOLZAPFEL_MODEL = "Holzapfel";
 const std::string ConstitutiveModelParameters::LEE_SACKS = "Lee-Sacks";
 const std::string ConstitutiveModelParameters::NEOHOOKEAN_MODEL = "neoHookean";
 const std::string ConstitutiveModelParameters::STVENANT_KIRCHHOFF_MODEL = "stVenantKirchhoff";
@@ -471,6 +472,8 @@ const std::map<std::string, std::string> ConstitutiveModelParameters::constituti
   { "Gucci",                                     ConstitutiveModelParameters::GUCCIONE_MODEL},
 
   {ConstitutiveModelParameters::HGO_MODEL, ConstitutiveModelParameters::HGO_MODEL},
+
+  {ConstitutiveModelParameters::HOLZAPFEL_MODEL, ConstitutiveModelParameters::HOLZAPFEL_MODEL},
 
   {ConstitutiveModelParameters::LEE_SACKS, ConstitutiveModelParameters::LEE_SACKS},
 
@@ -489,6 +492,7 @@ using SetConstitutiveModelParamMapType = std::map<std::string, std::function<voi
 SetConstitutiveModelParamMapType SetConstitutiveModelParamMap = {
   {ConstitutiveModelParameters::GUCCIONE_MODEL, [](CmpType cp, CmpXmlType params) -> void {cp->guccione.set_values(params);}},
   {ConstitutiveModelParameters::HGO_MODEL, [](CmpType cp, CmpXmlType params) -> void {cp->holzapfel_gasser_ogden.set_values(params);}},
+  {ConstitutiveModelParameters::HOLZAPFEL_MODEL, [](CmpType cp, CmpXmlType params) -> void {cp->holzapfel.set_values(params);}},
   {ConstitutiveModelParameters::LEE_SACKS, [](CmpType cp, CmpXmlType params) -> void {cp->lee_sacks.set_values(params);}},
   {ConstitutiveModelParameters::NEOHOOKEAN_MODEL, [](CmpType cp, CmpXmlType params) -> void {cp->neo_hookean.set_values(params);}},
   {ConstitutiveModelParameters::STVENANT_KIRCHHOFF_MODEL, [](CmpType cp, CmpXmlType params) -> void {cp->stvenant_kirchhoff.set_values(params);}},
@@ -558,6 +562,8 @@ HolzapfelParameters::HolzapfelParameters()
 
   set_parameter("afs", 0.0, required, afs);
   set_parameter("bfs", 0.0, required, bfs);
+
+  set_parameter("k", 0.0, required, k);
 
   set_xml_element_name("Constitutive_model type=Holzapfel");
 }

--- a/Code/Source/svFSI/Parameters.h
+++ b/Code/Source/svFSI/Parameters.h
@@ -454,6 +454,7 @@ class HolzapfelParameters : public ParameterLists
     Parameter<double> b4s;
     Parameter<double> afs;
     Parameter<double> bfs;
+    Parameter<double> k;
 
     bool value_set = false;
 };
@@ -517,6 +518,7 @@ class ConstitutiveModelParameters : public ParameterLists
     // Model types supported.
     static const std::string GUCCIONE_MODEL;
     static const std::string HGO_MODEL;
+    static const std::string HOLZAPFEL_MODEL;
     static const std::string LEE_SACKS;
     static const std::string NEOHOOKEAN_MODEL;
     static const std::string STVENANT_KIRCHHOFF_MODEL;

--- a/Code/Source/svFSI/set_material_props.h
+++ b/Code/Source/svFSI/set_material_props.h
@@ -153,6 +153,7 @@ SeMaterialPropertiesMapType set_material_props = {
   lDmn.stM.bss = params.b4s.value();
   lDmn.stM.afs = params.afs.value();
   lDmn.stM.bfs = params.bfs.value();
+  lDmn.stM.khs = params.k.value();
 } },
 
 //---------------------------//


### PR DESCRIPTION
This is for https://github.com/SimVascular/svFSIplus/issues/103#.

Note that the current material models in svFSIplus are different from svFSI. 