### PR TITLE
Fix bug in set_bc_rbnl

### DIFF
--- a/Code/Source/svFSI/set_bc.cpp
+++ b/Code/Source/svFSI/set_bc.cpp
@@ -1346,7 +1346,7 @@ void set_bc_rbnl(ComMod& com_mod, const faceType& lFa, const double ks, const do
     for (int a = 0; a < eNoN; a++) {
       int Ac = lFa.IEN(a,e);
       ptr(a) = Ac;
-      for (int i = 0; i < nsd; a++) {
+      for (int i = 0; i < nsd; i++) {
         xl(i,a) = com_mod.x(i,Ac);
         yl(i,a) = Yg(i+s,Ac);
         dl(i,a) = Dg(i+s,Ac);


### PR DESCRIPTION
Addressing Issue #133 [Link to Issue](https://github.com/SimVascular/svFSIplus/issues/133)

Changed the for loop in set_bc.cpp (line 1349) iterating a instead of i, which was causing a seg fault when using a robin BC.