### PR TITLE
Correct array dimensions for EquationProps.

### DIFF
--- a/Code/Source/svFSI/read_files.h
+++ b/Code/Source/svFSI/read_files.h
@@ -47,7 +47,7 @@ namespace read_files_ns {
   using EquationNdop = std::array<int, 4>;
   using EquationOutputs = std::array<consts::OutputType, maxOutput>;
   using EquationPhys = std::vector<consts::EquationType>;
-  using EquationProps = std::array<std::array<consts::PhysicalProperyType, consts::maxNProp>, 10>;
+  using EquationProps = std::array<std::array<consts::PhysicalProperyType, 10>, consts::maxNProp>;
 
   void face_match(ComMod& com_mod, faceType& lFa, faceType& gFa, Vector<int>& ptr);
 


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation
The dimensions of the `EquationProps` array were reversed causing a segfault on Apple Silicon Sonoma (see https://github.com/SimVascular/svFSIplus/issues/92).

## Testing
All tests should now pass on Apple Silicon Sonoma.


## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
