### PR TITLE
Replace CMM results by macOS 14 ones

### DIFF
--- a/tests/cases/cmm_3d_pipe/2b-prestress/result_003.vtu
+++ b/tests/cases/cmm_3d_pipe/2b-prestress/result_003.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d5e9a6a5356888fd0f8691e3af98a646f8a92ad6957d59edfc7e110065eab73e
-size 189246
+oid sha256:cd633b0bca01fee6efe4786e85df27b5622607825ed8deb88a2d29954cf1da7e
+size 252275


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation
macOS 14 Sonoma produces slightly different results than the test machines (#92). I replace the results for test `cmm_3d_pipe`/`2b-prestress` with the ones that Sonoma produced. I'm opening this PR to trigger the pipeline on the test machines. Not ready to merge!


## Release Notes 
None

## Documentation
None


## Testing
Tests pass locally on Sonoma


## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
