### PR TITLE
Add the SV_LOCAL_VTK_PATH CMake variable to use a local VTK build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ include(SimVascularFunctionCheckCompilerFlags)
 set(SV_USE_TRILINOS OFF CACHE BOOL "Use Trilinos Library with svFSI")
 set(ENABLE_COVERAGE OFF CACHE BOOL "Enable code coverage")
 set(ENABLE_ARRAY_INDEX_CHECKING OFF CACHE BOOL "Enable Array index checking")
+set(SV_LOCAL_VTK_PATH "" CACHE STRING "Path to a local build of VTK.")
 
 #-----------------------------------------------------------------------------
 # RPATH handling
@@ -117,7 +118,7 @@ set(SV_EXTERNALS_TOPLEVEL_DIR "${CMAKE_BINARY_DIR}/Externals-build/sv_externals"
 #-----------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------
-# svSolver!
+# svFSIplus solver.
 set(SV_ADDITIONAL_CMAKE_ARGS "" CACHE STRING "If more options want to be provided to the sv_externals build, they can be with this string")
 set(SV_APPLE_CMAKE_ARGS)
 ExternalProject_Add(svFSI
@@ -143,6 +144,7 @@ ExternalProject_Add(svFSI
     -DSV_USE_TRILINOS:BOOL=${SV_USE_TRILINOS}
     -DENABLE_COVERAGE:BOOL=${ENABLE_COVERAGE}
     -DENABLE_ARRAY_INDEX_CHECKING:BOOL=${ENABLE_ARRAY_INDEX_CHECKING}
+    -DSV_LOCAL_VTK_PATH:STRING=${SV_LOCAL_VTK_PATH}
     ${SV_APPLE_CMAKE_ARGS}
     ${SV_ADDITIONAL_CMAKE_ARGS}
     )

--- a/Code/Source/svFSI/CMakeLists.txt
+++ b/Code/Source/svFSI/CMakeLists.txt
@@ -71,11 +71,15 @@ endif()
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
 
-# Including VTK produces warnings when compiling Fortran code.
+# Include VTK either from a local build using SV_LOCAL_VTK_PATH
+# or from a default installed version.
 #
-#   -iframe is valid for C/C++/ObjC/ObjC++ but not for Fortran
-#
-find_package(VTK REQUIRED)
+if("${SV_LOCAL_VTK_PATH}" STREQUAL "")
+  find_package(VTK REQUIRED ) 
+else()
+  find_package(VTK PATHS ${SV_LOCAL_VTK_PATH} NO_DEFAULT_PATH REQUIRED) 
+endif()
+
 include(${VTK_USE_FILE})
 
 set(lib ${SV_LIB_SVFSI_NAME})
@@ -167,9 +171,6 @@ simvascular_add_executable(${SV_SVFSI_EXE}
   INSTALL_SCRIPT_NAME "svfsi"
   INSTALL_COMP CoreExecutables
   INSTALL_DESTINATION ${SV_INSTALL_RUNTIME_DIR})
-
-message("##### TINY  ${TINYXML_LIBRARY_NAME}")
-message("##### TET ${TETGEN_LIBRARY_NAME}")
 
 target_link_libraries(${SV_SVFSI_EXE}
   ${GLOBAL_LIBRARIES}


### PR DESCRIPTION
These changes allow building svFSIplus using a local build of VTK. This should be useful for building svFSIplus on an HPC cluster.

