### PR TITLE
Add CMake commands to use PETSc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,9 @@ include(SimVascularFunctionCheckCompilerFlags)
 #
 # These variables must later be add to 'ExternalProject_Add(svFSI' as -D options. 
 #
-set(SV_USE_TRILINOS OFF CACHE BOOL "Use Trilinos Library with svFSI")
+set(SV_USE_TRILINOS OFF CACHE BOOL "Build with the Trilinos linear algebra package")
+#set(SV_USE_PETSC OFF CACHE BOOL "Build with the PETSc linear algebra package")
+set(SV_PETSC_DIR "" CACHE STRING "Path to a local install of the PETSc linear algebra package")
 set(ENABLE_COVERAGE OFF CACHE BOOL "Enable code coverage")
 set(ENABLE_ARRAY_INDEX_CHECKING OFF CACHE BOOL "Enable Array index checking")
 set(SV_LOCAL_VTK_PATH "" CACHE STRING "Path to a local build of VTK.")
@@ -142,6 +144,8 @@ ExternalProject_Add(svFSI
     -DSV_EXTERNALS_USE_TOPLEVEL_DIR:BOOL=ON
     -DSV_EXTERNALS_TOPLEVEL_DIR:PATH=${SV_EXTERNALS_TOPLEVEL_DIR}
     -DSV_USE_TRILINOS:BOOL=${SV_USE_TRILINOS}
+    #-DSV_USE_PETSC:BOOL=${SV_USE_PETSC}
+    -DSV_PETSC_DIR:STRING=${SV_PETSC_DIR}
     -DENABLE_COVERAGE:BOOL=${ENABLE_COVERAGE}
     -DENABLE_ARRAY_INDEX_CHECKING:BOOL=${ENABLE_ARRAY_INDEX_CHECKING}
     -DSV_LOCAL_VTK_PATH:STRING=${SV_LOCAL_VTK_PATH}

--- a/Code/Source/svFSI/CMakeLists.txt
+++ b/Code/Source/svFSI/CMakeLists.txt
@@ -49,8 +49,7 @@ if(SV_USE_TRILINOS)
       MESSAGE(WARNING "Trilinos_FOUND is true but Trilinos_LIBRARIES is empty. This suggests that FIND_PACKAGE(Trilinos) failed quietly. Proceed with caution.")
     endif()
 
-    MESSAGE("Setting WITH_TRILINOS to true\n")
-    set(WITH_TRILINOS 1)
+    set(USE_TRILINOS 1)
   ELSE()
     MESSAGE(WARNING "Could not find Trilinos. Compiling svFSI without Trilinos.")
   ENDIF()
@@ -58,9 +57,46 @@ if(SV_USE_TRILINOS)
 endif()
 
 # add trilinos flags and defines
-if(WITH_TRILINOS)
+if(USE_TRILINOS)
   ADD_DEFINITIONS(-DWITH_TRILINOS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
+
+# Build with the PETSc linear algebra package.
+#
+if(NOT "${SV_PETSC_DIR}" STREQUAL "")
+
+   if(NOT EXISTS ${SV_PETSC_DIR})
+      message(ERROR "The PETSc directory ${SV_PETSC_DIR} could not be found.")
+   endif()
+
+   if(NOT EXISTS "${SV_PETSC_DIR}/include")
+      message(ERROR "The PETSc include directory ${SV_PETSC_DIR}/include could not be found.")
+   endif()
+
+   if(NOT EXISTS "${SV_PETSC_DIR}/lib")
+      message(ERROR "The PETSc library directory ${SV_PETSC_DIR}/lib could not be found.")
+   endif()
+
+  set(PETSC_INCLUDE_DIRS "${SV_PETSC_DIR}/include;${SV_PETSC_DIR}/../include")
+  set(PETSC_LIBRARY_DIRS "-L${SV_PETSC_DIR}/lib -lpetsc")
+  message("\nBuilding with the PETSc package; the include and libraries directories are: ")
+  message("  PETSC_LIBRARY_DIRS = ${PETSC_LIBRARY_DIRS}")
+  message("  PETSC_INCLUDE_DIRS = ${PETSC_INCLUDE_DIRS}")
+
+  # Set PETSc include directory.
+  include_directories(${PETSC_INCLUDE_DIRS})
+
+  # Set C++ directive to use PETSc in svFSIplus code.
+  ADD_DEFINITIONS(-DWITH_PETSC)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic -std=c99")
+
+  set(USE_PETSC 1)
+
+else()
+
+  set(USE_PETSC 0)
+
 endif()
 
 if(ENABLE_ARRAY_INDEX_CHECKING)
@@ -155,7 +191,12 @@ set(CSRCS
   SPLIT.c
 )
 
-if(WITH_TRILINOS)
+  # Set PETSc interace code.
+  if(USE_PETSC)
+     #set(CSRCS ${CSRCS} petsc_linear_solver.c)
+  endif()
+
+if(USE_TRILINOS)
   set(CSRCS ${CSRCS} trilinos_linear_solver.cpp)
 
   # trilinos directories and libraries
@@ -191,8 +232,12 @@ if(SV_MPI_EXTRA_LIBRARY)
   target_link_libraries(${SV_SVFSI_EXE} ${SV_MPI_EXTRA_LIBRARY})
 endif()
 
-if(WITH_TRILINOS)
+if(USE_TRILINOS)
   target_link_libraries(${SV_SVFSI_EXE} ${Trilinos_LIBRARIES} ${Trilinos_TPL_LIBRARIES})
+endif()
+
+if(USE_PETSC)
+  target_link_libraries(${SV_SVFSI_EXE} ${PETSC_LIBRARY_DIRS})
 endif()
 
 # coverage


### PR DESCRIPTION
I've added an SV_PETSC_DIR option to set the PETSc install directory and CMake commands to define PETSc include and library flags (see https://github.com/SimVascular/svFSIplus/issues/181).