### PR TITLE
Bug fix in Holzapfel tangent component

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           git lfs pull
           cd tests
-          conda run -n svfsiplus pytest -v --durations=0
+          conda run -n svfsiplus pytest -rPv --durations=0
       - name: Generate code coverage
         if: startsWith(matrix.os, 'ubuntu-22.04')
         run: |

--- a/Code/Source/svFSI/mat_models_carray.h
+++ b/Code/Source/svFSI/mat_models_carray.h
@@ -943,7 +943,7 @@ void get_pk2cc(const ComMod& com_mod, const CepMod& cep_mod, const dmnType& lDmn
           for (int j = 0; j < N; j++) {
             for (int k = 0; k < N; k++) {
               for (int l = 0; l < N; l++) {
-                CCb[i][j][k][l] += g1 * Hss_prod[i][j][k][l];
+                CCb[i][j][k][l] += g2 * Hss_prod[i][j][k][l];
               }
             }
           }


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation
Holzapfel material test case has very slow convergence (https://github.com/SimVascular/svFSIplus/issues/189). This was introduced during material model restructuring (https://github.com/SimVascular/svFSIplus/pull/159). 


## Release Notes 
- Miniscule bug fix in one component of the tangent matrix for the Holzapfel material model


## Testing
test_LV_Holzapfel_passive now displays excellent convergence
```
---------------------------------------------------------------------
 Eq     N-i     T       dB  Ri/R1   Ri/R0    R/Ri     lsIt   dB  %t
---------------------------------------------------------------------
 ST 1-1  3.900e-02  [0 1.000e+00 1.000e+00 8.962e-07]  [84 -45 13]
 ST 1-2  8.100e-02  [-25 5.159e-02 5.159e-02 9.870e-07]  [92 -55 14]
 ST 1-3  1.240e-01  [-74 1.835e-04 1.835e-04 9.218e-07]  [89 -51 12]
 ST 1-4s 2.200e-01  [-194 1.800e-10 1.800e-10 1.448e-03]  [47 -65 13]
```


## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
