### PR TITLE
Replace fsi_ls_upd() call that was mistakenly removed in https://gith…

### DIFF
--- a/Code/Source/svFSI/eq_assem.cpp
+++ b/Code/Source/svFSI/eq_assem.cpp
@@ -102,7 +102,7 @@ void b_assem_neu_bc(ComMod& com_mod, const faceType& lFa, const Vector<double>& 
 
     for (int g = 0; g < lFa.nG; g++) {
       Vector<double> nV(nsd);
-      auto Nx = lFa.Nx.slice(g);
+      auto Nx = lFa.Nx.rslice(g);
       nn::gnnb(com_mod, lFa, e, g, nsd, nsd-1, eNoN, Nx, nV);
       double Jac = sqrt(utils::norm(nV));
       nV = nV / Jac;
@@ -271,7 +271,7 @@ void b_neu_folw_p(ComMod& com_mod, const bcType& lBc, const faceType& lFa, const
 
       // Get surface normal vector
       Vector<double> nV(nsd);
-      auto Nx_g = lFa.Nx.slice(g);
+      auto Nx_g = lFa.Nx.rslice(g);
       nn::gnnb(com_mod, lFa, e, g, nsd, nsd-1, eNoNb, Nx_g, nV);
       Jac = sqrt(utils::norm(nV));
       nV = nV / Jac;
@@ -345,7 +345,7 @@ void fsi_ls_upd(ComMod& com_mod, const bcType& lBc, const faceType& lFa)
     }
     for (int g = 0; g < lFa.nG; g++) {
       Vector<double> n(nsd);
-      auto Nx = lFa.Nx.slice(g);
+      auto Nx = lFa.Nx.rslice(g);
 
       auto cfg = MechanicalConfigurationType::new_timestep;
 

--- a/Code/Source/svFSI/eq_assem.cpp
+++ b/Code/Source/svFSI/eq_assem.cpp
@@ -302,6 +302,74 @@ void b_neu_folw_p(ComMod& com_mod, const bcType& lBc, const faceType& lFa, const
   }
 }
 
+/// @brief Update the surface integral involved in the coupled/resistance BC
+/// contribution to the stiffness matrix to reflect deformed geometry, if using
+/// a follower pressure load.
+/// The value of this integral is stored in lhs%face%val.
+/// This integral is sV = int_Gammat (Na * n_i) (See Brown et al. 2024, Eq. 56)
+/// where Na is the shape function and n_i is the normal vector.
+///
+/// This function updates the variable lhs%face%val with the new value, which
+/// is eventually used in ADDBCMUL() in the linear solver to add the contribution
+/// from the resistance BC to the matrix-vector product of the tangent matrix and
+/// an arbitrary vector.
+void fsi_ls_upd(ComMod& com_mod, const bcType& lBc, const faceType& lFa)
+{
+  using namespace consts;
+  using namespace utils;
+  using namespace fsi_linear_solver;
+
+  #define n_debug_fsi_ls_upd
+  #ifdef debug_fsi_ls_upd
+  DebugMsg dmsg(__func__, com_mod.cm.idcm());
+  dmsg.banner();
+  dmsg << "lFa.name: " << lFa.name;
+  #endif
+
+  auto& cm = com_mod.cm;
+  int nsd = com_mod.nsd;
+  int tnNo = com_mod.tnNo;
+
+  int iM = lFa.iM;
+  int nNo = lFa.nNo;
+
+  Array<double> sVl(nsd,nNo); 
+  Array<double> sV(nsd,tnNo); 
+
+  // Updating the value of the surface integral of the normal vector
+  // using the deformed configuration ('n' = new = timestep n+1)
+  sV = 0.0;
+  for (int e = 0; e < lFa.nEl; e++) {
+    if (lFa.eType == ElementType::NRB) {
+      // CALL NRBNNXB(msh(iM),lFa,e)
+    }
+    for (int g = 0; g < lFa.nG; g++) {
+      Vector<double> n(nsd);
+      auto Nx = lFa.Nx.slice(g);
+
+      auto cfg = MechanicalConfigurationType::new_timestep;
+
+      nn::gnnb(com_mod, lFa, e, g, nsd, nsd-1, lFa.eNoN, Nx, n, cfg);
+      // 
+      for (int a = 0; a < lFa.eNoN; a++) {
+        int Ac = lFa.IEN(a,e);
+        for (int i = 0; i < nsd; i++) {
+          sV(i,Ac) = sV(i,Ac) + lFa.N(a,g)*lFa.w(g)*n(i);
+        }
+      }
+    }
+  }
+
+  if (sVl.size() != 0) { 
+    for (int a = 0; a < lFa.nNo; a++) {
+      int Ac = lFa.gN(a);
+      sVl.set_col(a, sV.col(Ac));
+    }
+  }
+  // Update lhs.face(i).val with the new value of the surface integral
+  fsils_bc_update(com_mod.lhs, lBc.lsPtr, lFa.nNo, nsd, sVl); 
+};
+
 /// @brief This routine assembles the equation on a given mesh.
 ///
 /// Ag(tDof,tnNo), Yg(tDof,tnNo), Dg(tDof,tnNo)

--- a/Code/Source/svFSI/set_bc.cpp
+++ b/Code/Source/svFSI/set_bc.cpp
@@ -1449,6 +1449,16 @@ void set_bc_neu_l(ComMod& com_mod, const CmMod& cm_mod, const bcType& lBc, const
     eq_assem::b_assem_neu_bc(com_mod, lFa, hg, Yg);
   }
 
+
+  // Now update surface integrals involved in coupled/resistance BC
+  // contribution to stiffness matrix to reflect deformed geometry.
+  // We must do this if we have a resistance boundary condition and
+  // a follower pressure load (struct/ustruct) or a moving mesh (FSI)
+  if (utils::btest(lBc.bType, iBC_res)) {
+    if (lBc.flwP || com_mod.mvMsh) {
+      eq_assem::fsi_ls_upd(com_mod, lBc, lFa);
+    }
+  }
   // Now treat Robin BC (stiffness and damping) here
   //
   if (utils::btest(lBc.bType,iBC_Robin)) {

--- a/tests/cases/struct/LV_NeoHookean_passive_sv0D/result_003.vtu
+++ b/tests/cases/struct/LV_NeoHookean_passive_sv0D/result_003.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8fedc58a8d94f7369a6a1a63d7cead2144adebec013b3c01d62175dc6242d4d7
-size 248369
+oid sha256:6815344539ccdb79eac642845b60f9746d5cb5a0c70ccd0c079d4323405d31dc
+size 248341

--- a/tests/cases/struct/LV_NeoHookean_passive_sv0D/svFSI.xml
+++ b/tests/cases/struct/LV_NeoHookean_passive_sv0D/svFSI.xml
@@ -50,7 +50,7 @@
 
    <Coupled> true </Coupled>
    <Min_iterations> 3 </Min_iterations>  
-   <Max_iterations> 10 </Max_iterations> 
+   <Max_iterations> 20 </Max_iterations> 
    <Tolerance> 1e-9 </Tolerance> 
 
    <Density> 1.0 </Density>                           <!-- g/cm^3 -->


### PR DESCRIPTION
…ub.com/SimVascular/svFSIplus/pull/216. Also, call it if mvMsh is true, which I think is necessary for FSI sims. This improves nonlinear convergence in 0D-coupled struct/ustruct test cases.

<!-- Give your pull request (PR) a descriptive name -->

## Current situation
https://github.com/SimVascular/svFSIplus/issues/239


## Release Notes 
- Replaces fsi_ls_upd() definition and subsequent call, which was mistakenly removed in a previous commit


## Testing
- No new tests, but existing struct/ustruct 0D-coupled tests (struct/LV_NeoHookean_passive_genBC, struct/LV_NeoHookean_passive_sv0D, ustruct/LV_NeoHookean_passive_genBC, ustruct/LV_NeoHookean_passive_sv0D) display improved nonlinear convergence


## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
