### PR TITLE
Fix reading in traction values file path vtu file 235

### DIFF
--- a/Code/Source/svFSI/VtkData.cpp
+++ b/Code/Source/svFSI/VtkData.cpp
@@ -926,6 +926,24 @@ void VtkVtuData::copy_point_data(const std::string& data_name, Vector<int>& mesh
   }
 }
 
+/// @brief Copy points into the given array.
+//
+void VtkVtuData::copy_points(Array<double>& points)
+{ 
+  auto vtk_points = impl->vtk_ugrid->GetPoints();
+  auto num_points = vtk_points->GetNumberOfPoints();
+  Array<double> points_array(3, num_points);
+  
+  double point[3];
+  for (int i = 0; i < num_points; i++) {
+    vtk_points->GetPoint(i, point);
+    points(0,i) = point[0];
+    points(1,i) = point[1];
+    points(2,i) = point[2];
+  } 
+  
+  return;
+}
 
 bool VtkVtuData::has_point_data(const std::string& data_name)
 {

--- a/Code/Source/svFSI/VtkData.h
+++ b/Code/Source/svFSI/VtkData.h
@@ -60,6 +60,7 @@ class VtkData {
 
     virtual bool has_point_data(const std::string& data_name) = 0;
 
+    virtual void copy_points(Array<double>& points) = 0;
     virtual void copy_point_data(const std::string& data_name, Array<double>& mesh_data) = 0;
     virtual void copy_point_data(const std::string& data_name, Vector<double>& mesh_data) = 0;
     virtual void write() = 0;
@@ -119,6 +120,7 @@ class VtkVtuData : public VtkData {
     virtual int num_points();
     virtual void read_file(const std::string& file_name);
 
+    void copy_points(Array<double>& points);
     void copy_point_data(const std::string& data_name, Array<double>& mesh_data);
     void copy_point_data(const std::string& data_name, Vector<double>& mesh_data);
     void copy_point_data(const std::string& data_name, Vector<int>& mesh_data);

--- a/Code/Source/svFSI/read_files.cpp
+++ b/Code/Source/svFSI/read_files.cpp
@@ -2671,7 +2671,7 @@ void read_temporal_values(const std::string& file_name, bfType& lBf)
 //----------------
 // read_trac_bcff
 //----------------
-// Reads pressure/traction data from a vtp file and stores in moving BC data structure.
+// Reads pressure/traction data from a vtk vtp or vtu file and stores in moving BC data structure.
 //
 // Reproduces 'SUBROUTINE READTRACBCFF(lMB, lFa, fName)' defined in READFILES.f.
 //
@@ -2683,9 +2683,8 @@ void read_trac_bcff(ComMod& com_mod, MBType& lMB, faceType& lFa, const std::stri
     throw std::runtime_error("The VTK VTP traction data file '" + fName + "' can't be read.");
   }
 
-  // Read the vtp file.
+  // Read the vtk file.
   //
-  //VtkVtpData vtp_data(fName);
   auto vtk_data = VtkData::create_reader(fName);
   int num_points = vtk_data->num_points();
   if (num_points == 0) {

--- a/Code/Source/svFSI/read_files.cpp
+++ b/Code/Source/svFSI/read_files.cpp
@@ -2685,13 +2685,14 @@ void read_trac_bcff(ComMod& com_mod, MBType& lMB, faceType& lFa, const std::stri
 
   // Read the vtp file.
   //
-  VtkVtpData vtp_data(fName);
-  int num_points = vtp_data.num_points();
+  //VtkVtpData vtp_data(fName);
+  auto vtk_data = VtkData::create_reader(fName);
+  int num_points = vtk_data->num_points();
   if (num_points == 0) {
     throw std::runtime_error("The VTK VTP traction data file '" + fName + "' does not contain any points.");
   }
 
-  int num_elems = vtp_data.num_elems();
+  int num_elems = vtk_data->num_elems();
   if (num_elems == 0) {
     throw std::runtime_error("The VTK VTP traction data file '" + fName + "' does not contain any elements.");
   }
@@ -2706,7 +2707,7 @@ void read_trac_bcff(ComMod& com_mod, MBType& lMB, faceType& lFa, const std::stri
   }
 
   // Check that the vtk file has traction data.
-  if (!vtp_data.has_point_data(data_name)) {
+  if (!vtk_data->has_point_data(data_name)) {
     throw std::runtime_error("No PointData DataArray named '" + data_name + "' found in the VTK VTP traction data file '" + fName +
         "' for the '" + lFa.name + "' face.");
   }
@@ -2719,7 +2720,7 @@ void read_trac_bcff(ComMod& com_mod, MBType& lMB, faceType& lFa, const std::stri
   faceType gFa;
   gFa.nNo = num_points;
   gFa.x.resize(com_mod.nsd, gFa.nNo);
-  vtp_data.copy_points(tmpX2);
+  vtk_data->copy_points(tmpX2);
 
   for (int i = 0; i < num_points; i++) {
     for (int j = 0; j < com_mod.nsd; j++) {
@@ -2728,9 +2729,9 @@ void read_trac_bcff(ComMod& com_mod, MBType& lMB, faceType& lFa, const std::stri
   }
 
   if (data_name == "Pressure") {
-    vtp_data.copy_point_data(data_name, tmpX1);
+    vtk_data->copy_point_data(data_name, tmpX1);
   } else { 
-    vtp_data.copy_point_data(data_name, tmpX2);
+    vtk_data->copy_point_data(data_name, tmpX2);
   }
 
   // Project traction from gFa to lFa. First prepare lFa%x, lFa%IEN

--- a/Code/Source/svFSI/vtk_xml.cpp
+++ b/Code/Source/svFSI/vtk_xml.cpp
@@ -672,7 +672,7 @@ void read_vtu_pdata(const std::string& fName, const std::string& kwrd, const int
     throw std::runtime_error("The VTK VTU pressure data file '" + fName + "' can't be read.");
   }
 
-  // Read the vtu file.
+  // Read the vtk file.
   //
   auto vtk_data = VtkData::create_reader(fName);
   int num_elems = vtk_data->num_elems();


### PR DESCRIPTION
I've modified the `read_trac_bcff()` function to read vtp and vtu files for the `Traction_values_file_path`.

Note that there are no tests for the `Traction_values_file_path` keyword.