### PR TITLE
From DoD meeting: add a warning message to the log when max nonlinear iterations are reached. Issue #192

### DIFF
--- a/Code/Source/svFSI/output.cpp
+++ b/Code/Source/svFSI/output.cpp
@@ -165,6 +165,12 @@ void output_result(Simulation* simulation,  std::array<double,3>& timeP, const i
   } else {
     logger << sOut << std::endl;
   }
+
+  // if max number of iterations is reached, throw a warning
+  if (eq.itr == eq.maxItr) {
+    logger << "MAX NUMBER OF NONLINEAR ITERATIONS REACHED. CHECK CONVERGENCE." << std::endl;
+  }
+
 }
 
 void read_restart_header(ComMod& com_mod, std::array<int,7>& tStamp, double& timeP, std::ifstream& restart_file)


### PR DESCRIPTION
## Current situation
The solver does not throw a warning message when the max number of nonlinear iterations are reached, as pointed out in the following issue: #192 

## Release Notes 
We ( @dcodoni and @aabrown100-git and I ) added a warning message to the log when max nonlinear iterations are reached. For now, per Dave's suggestion, we decided to not terminate the simulation. We may also want to add a user flag, if desired by the development team.

## Testing
No testing required. To test this feature, reduce the max number of iterations in a test case and observe the output.

## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
