### PR TITLE
Bring back the badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # svFSIplus
 
+[![Build Status](https://github.com/SimVascular/svFSIplus/actions/workflows/test.yml/badge.svg)](https://github.com/SimVascular/svFSIplus/actions)
+[![codecov](https://codecov.io/github/SimVascular/svFSIplus/graph/badge.svg?token=I848DNIHSP)](https://codecov.io/github/SimVascular/svFSIplus)
+![Latest Release](https://img.shields.io/github/v/release/SimVascular/svFSIplus?label=latest)
+![Platform](https://img.shields.io/badge/platform-macOS%20|%20linux-blue)
+[![DOI](https://img.shields.io/badge/DOI-10.21105%2Fjoss.04118-green)](https://doi.org/10.21105/joss.04118)
+
 ### Table of Contents
 **[Introduction](#introduction)**<br>
 **[Building the svFSIplus Program from Source](#building)**<br>


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation
The badges were removed in 058a2b80eef5f969feb1571d471bc0a2f0625dec

## Release Notes 
Most repositories on GitHub have badges for a quick overview of key repository facts (tests, coverage, reference, release, OS).

## Documentation
None

## Testing
Badges look good in my fork (except for the build one, which only works in the main repository).

## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
