### PR TITLE
Upgrading macOS version in the test_macos.yml (addresses #278)

### DIFF
--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -1,8 +1,8 @@
-name: macOS 12
+name: macOS
 on: [push, pull_request]
 jobs:
   test:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install MacOS dependencies
@@ -12,6 +12,12 @@ jobs:
           brew install lcov
           sudo ln -s /usr/local/opt/qt5/mkspecs /usr/local/mkspecs
           sudo ln -s /usr/local/opt/qt5/plugins /usr/local/plugins
+          # Install Miniconda
+      - name: Install Miniconda
+        run: |
+          curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+          bash Miniconda3-latest-MacOSX-x86_64.sh -b -p $HOME/miniconda
+          echo "$HOME/miniconda/bin" >> $GITHUB_PATH
       - name: Build svZeroDSolver
         run: |
           git clone https://github.com/SimVascular/svZeroDSolver.git

--- a/tests/cases/fluid/newtonian/svFSIplus.xml
+++ b/tests/cases/fluid/newtonian/svFSIplus.xml
@@ -69,7 +69,7 @@
          <Preconditioner> fsils </Preconditioner>
       </Linear_algebra>
      <Max_iterations> 100 </Max_iterations>
-     <Tolerance> 1e-12 </Tolerance>
+     <Tolerance> 1e-14 </Tolerance>
    </LS>
 
    <Add_BC name="lumen_inlet" > 

--- a/tests/cases/fluid/newtonian/svFSIplus.xml
+++ b/tests/cases/fluid/newtonian/svFSIplus.xml
@@ -45,7 +45,7 @@
 
    <Coupled> true </Coupled>
    <Min_iterations> 1 </Min_iterations>  
-   <Max_iterations> 4 </Max_iterations> 
+   <Max_iterations> 10 </Max_iterations> 
    <Tolerance> 1e-11 </Tolerance> 
    <Backflow_stabilization_coefficient> 0.2 </Backflow_stabilization_coefficient> 
 


### PR DESCRIPTION
* upgrade the macOS version to the latest available
* add in the workflow conda installation

## Current situation
Currently the workflow file running integration tests on macOS uses an old and specific version of macOS (macOS 12). This now is creating problems, in particular the installation of necessary packages is taking around 5 hours (6 hours is the limit to complete the testing).

## Release Notes 
I upgraded the macOS version in the workflow file and I set it to macOS-latest.

## Testing
* no further testing is necessary

## Code of Conduct & Contributing Guidelines 
- [ ] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
