### PR TITLE
Fixed unknown coupled BC type when using genBC or svZeroD solver in FSI

### DIFF
--- a/Code/Source/solver/read_files.cpp
+++ b/Code/Source/solver/read_files.cpp
@@ -1404,7 +1404,7 @@ void read_eq(Simulation* simulation, EquationParameters* eq_params, eqType& lEq)
       cplbc_type_str = eq_params->couple_to_cplBC.type.value();
     }
 
-    if ((cplBC.useGenBC || cplBC.useSvZeroD) && !cplbc_type_str.empty()) {
+    if (eq_params->couple_to_genBC.defined() || eq_params->couple_to_cplBC.defined() || eq_params->svzerodsolver_interface_parameters.defined()) { 
       try {
         cplBC.schm = consts::cplbc_name_to_type.at(cplbc_type_str);
       } catch (const std::out_of_range& exception) {


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation
Solves https://github.com/SimVascular/svMultiPhysics/issues/462


## Release Notes 
FSI simulation with genBC or svZeroDSolver coupled boundary conditions produces `Unknown coupled BC type` error because `cplBC.useGenBC` or `cplBC.useSvZeroD` are already true when reading the mesh motion equation, even though they are not defined for the mesh motion equation. An additional check for `cplbc_type_str` is added to avoid checking the coupled BC type for the mesh motion equation.


## Testing
Tested using the 3D pipe case in FSI with both svZeroD solver and genBC.


## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
