### PR TITLE
Allow zero fiber/sheet vectors in compute_sheet_normal

### DIFF
--- a/Code/Source/solver/mat_models.cpp
+++ b/Code/Source/solver/mat_models.cpp
@@ -295,12 +295,18 @@ Eigen::Matrix<double, nsd, 1> compute_sheet_normal(const Eigen::Matrix<double, n
     throw std::runtime_error("Sheet-normal active stress (eta_n > 0) is not defined in 2D.");
     
   } else {  // nsd == 3
+    // Zero fiber/sheet vector means no fibers in this region: return zero so Hnn = n*n^T = 0.
+    static constexpr double fib_zero_tol = 1.0e-10;
+    if (fl.col(0).norm() < fib_zero_tol || fl.col(1).norm() < fib_zero_tol) {
+      return Eigen::Matrix<double, nsd, 1>::Zero();
+    }
+
     auto n_normal = cross_product<nsd>(fl.col(0), fl.col(1));
     double norm_n = sqrt(n_normal.dot(n_normal));
-    
-    static constexpr double sheet_normal_tol = 1.0e-10; 
+
+    static constexpr double sheet_normal_tol = 1.0e-10;
     if (norm_n < sheet_normal_tol) {
-      throw std::runtime_error("Fiber and sheet directions are parallel; sheet-normal direction is undefined.");
+      throw std::runtime_error("Fiber and sheet directions are non-zero but parallel; sheet-normal direction is undefined.");
     }
 
     return n_normal / norm_n;


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation
compute_sheet_normal in mat_models.cpp threw an error when the cross product of fiber and sheet vectors was below some tolerance (i.e. they are parallel.) This prevented assigning zero vector fibers on regions of the mesh where active/passive fibers should not contribute. This PR skips the runtime error message when the vectors have zero magnitude but raises an error when nonzero vectors are parallel.

## Release Notes 
Fixed compute_sheet_normal to allow zero fiber/sheet direction vectors. Regions with zero vectors now contribute no anisotropic stress, rather than causing a runtime error.

```
// Zero fiber/sheet vector means no fibers in this region: return zero so Hnn = n*n^T = 0.
    static constexpr double fib_zero_tol = 1.0e-10;
    if (fl.col(0).norm() < fib_zero_tol || fl.col(1).norm() < fib_zero_tol) {
      return Eigen::Matrix<double, nsd, 1>::Zero();
    }
```


## Documentation
 <!-- todo developers: add documentation guide -->
*Please ensure that you properly document any additions.*


## Testing
*Please ensure that the PR meets the testing requirements set by GitHub Actions.*
 <!-- todo developers: check for coverage in GitHub Actions -->
*In addition, please ensure all modified and new code is covered by tests.*


## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
