### PR TITLE
Updated RIS valve upstream direction and mean pressure integration domain, added an optional argument to invert RIS surface normal

### DIFF
--- a/Code/Source/solver/ComMod.h
+++ b/Code/Source/solver/ComMod.h
@@ -1482,6 +1482,9 @@ class urisType
     // if the fully closed position alone is not able to prevent backflow.
     double sdf_deps_close;
 
+    // Whether to invert the valve surface normal vector.
+    bool invert_normal;
+
     // Opening positions of the valve surfaces.
     Array3<double> DxOpen;
 

--- a/Code/Source/solver/ComMod.h
+++ b/Code/Source/solver/ComMod.h
@@ -1483,10 +1483,11 @@ class urisType
     double sdf_deps_close;
 
     // Whether to invert the valve surface normal vector. Default is false.
-    // If true, inverts the shell face normal used for SDF sign calculation so the negative
-    // and positive SDF sides remain consistent with the upstream and downstream directions.
-    // Mesh face normals are assumed to point outward from the leaflet. Set to true if the
-    // surface mesh has inward-pointing normals to preserve the SDF sign convention.
+    // 
+    // Valve normal vectors are assumed to point downstream, so that the
+    // downstream region has positive signed distance and the upstream region
+    // has negative signed distance. If the input surface does not satisfy
+    // this assumption, this flag should be set to true to flip the normals.
     bool invert_normal;
 
     // Opening positions of the valve surfaces.

--- a/Code/Source/solver/ComMod.h
+++ b/Code/Source/solver/ComMod.h
@@ -1482,7 +1482,11 @@ class urisType
     // if the fully closed position alone is not able to prevent backflow.
     double sdf_deps_close;
 
-    // Whether to invert the valve surface normal vector.
+    // Whether to invert the valve surface normal vector. Default is false.
+    // If true, inverts the shell face normal used for SDF sign calculation so the negative
+    // and positive SDF sides remain consistent with the upstream and downstream directions.
+    // Mesh face normals are assumed to point outward from the leaflet. Set to true if the
+    // surface mesh has inward-pointing normals to preserve the SDF sign convention.
     bool invert_normal;
 
     // Opening positions of the valve surfaces.

--- a/Code/Source/solver/Parameters.cpp
+++ b/Code/Source/solver/Parameters.cpp
@@ -3003,6 +3003,7 @@ URISMeshParameters::URISMeshParameters()
   set_parameter("Resistance", 1.0e5,  !required, resistance);
   set_parameter("Closed_resistance", 1.0e5,  !required, resistance_close);
   set_parameter("Valve_starts_as_closed", true,  !required, valve_starts_as_closed);
+  set_parameter("Invert_normal", false,  !required, invert_normal);
   set_parameter("Positive_flow_normal_file_path", "",  !required, positive_flow_normal_file_path);
 }
 

--- a/Code/Source/solver/Parameters.h
+++ b/Code/Source/solver/Parameters.h
@@ -1730,6 +1730,7 @@ class URISMeshParameters : public ParameterLists
     Parameter<double> resistance; // Resistance of the valve
     Parameter<double> resistance_close; // Resistance of the valve when it is closed
     Parameter<bool> valve_starts_as_closed; // Whether the valve starts as closed
+    Parameter<bool> invert_normal; // Whether to invert the valve surface normal vector
     Parameter<std::string> positive_flow_normal_file_path; // File path for the positive flow normal
 
 };

--- a/Code/Source/solver/distribute.cpp
+++ b/Code/Source/solver/distribute.cpp
@@ -1178,6 +1178,7 @@ void dist_uris(ComMod& com_mod, const CmMod& cm_mod, const cmType& cm) {
     cm.bcast(cm_mod, &uris[iUris].sdf_deps);
     cm.bcast(cm_mod, &uris[iUris].sdf_deps_close);
     cm.bcast(cm_mod, &uris[iUris].clsFlg);
+    cm.bcast(cm_mod, &uris[iUris].invert_normal);
     cm.bcast(cm_mod, &uris[iUris].cnt);
     cm.bcast(cm_mod, &uris[iUris].scF);
     cm.bcast(cm_mod, uris[iUris].nrm);

--- a/Code/Source/solver/uris.cpp
+++ b/Code/Source/solver/uris.cpp
@@ -39,32 +39,30 @@ void uris_meanp(ComMod& com_mod, CmMod& cm_mod, const int iUris, const SolutionS
   auto& uris_obj = uris[iUris];
 
   const int nsd = com_mod.nsd;
-  // const int cEq = com_mod.cEq;
 
-  // auto& An = com_mod.An;
-  // auto& Ad = com_mod.Ad;
-  // auto& Dn = com_mod.Dn;
+  // Compute the mean pressure in the upstream and downstream regions of the fluid mesh 
 
-  // Let's conpute the mean pressure in the two regions of the fluid mesh 
-  // For the moment let's define a flag IdSubDmn(size the number of elements)
-
-  // Now we can compute the pressure mean on each subdomain
-  // We need to have a sdf array for each mesh
-  double Deps = uris_obj.sdf_deps * 2.5;
+  // Set the limit of the upstream and downstream regions to 5 times the closed 
+  // valve thickness. This should give a reasonable range for the upstream and 
+  // downstream regions.
+  double Deps = uris_obj.sdf_deps_close * 5.0;
   double volU = 0.0;
   double volD = 0.0;
 
-  // Let's compute left side 
-  Array<double> sUPS(1,com_mod.tnNo);
-  // std::cout << "com_mod.tnNo: " << com_mod.tnNo << std::endl;
-  // std::cout << "uris_obj.sdf size: " << uris_obj.sdf.size() << std::endl;
+  if (cm.mas(cm_mod)) {
+    std::cout << "Computing upstream region from SDF -" << Deps << " to -" 
+              << uris_obj.sdf_deps_close << " for: " << uris_obj.name << std::endl;
+    std::cout << "Computing downstream region from SDF " << uris_obj.sdf_deps_close 
+              << " to " << Deps << " for: " << uris_obj.name << std::endl;
+  }
 
+  // Compute the upstream region: negative sdf side (opposite to valve normal), 
+  // outside resistance region
+  Array<double> sUPS(1, com_mod.tnNo);
   sUPS = 0.0;
-  for (size_t j = 0; j < sUPS.size(); j++) {
-    if (uris_obj.sdf(j) >= 0.0 && uris_obj.sdf(j) <= Deps) {
-    // Reverse the sdf distance for aortic valve
-    // [HZ] Adjust this value to be more flexible about the box
-    // if (uris_obj.sdf(j) < 0.0 && uris_obj.sdf(j) >= -Deps) { 
+  for (size_t j = 0; j < com_mod.tnNo; j++) {
+    double sdf_j = uris_obj.sdf(j);
+    if (sdf_j >= -Deps && sdf_j <= -uris_obj.sdf_deps_close) {
         sUPS(0,j) = 1.0;
     }
   }
@@ -73,15 +71,14 @@ void uris_meanp(ComMod& com_mod, CmMod& cm_mod, const int iUris, const SolutionS
     volU += all_fun::integ(com_mod, cm_mod, iM, sUPS, solutions);
   }
 
-
-  // Let's compute right side
-  Array<double> sDST(1,com_mod.tnNo);
+  // Compute the downstream region: positive sdf side (valve normal direction), 
+  // outside resistance region
+  Array<double> sDST(1, com_mod.tnNo);
   sDST = 0.0;
-  for (size_t j = 0; j < sDST.size(); j++) {
-    if (uris_obj.sdf(j) < 0.0 && uris_obj.sdf(j) >= -Deps) {
-    // Reverse the sdf distance for aortic valve
-    // if (uris_obj.sdf(j) >= 0.0 && uris_obj.sdf(j) <= Deps) {
-        sDST(0,j) = 1.0;
+  for (size_t j = 0; j < com_mod.tnNo; j++) {
+    double sdf_j = uris_obj.sdf(j);
+    if (sdf_j >= uris_obj.sdf_deps_close && sdf_j <= Deps) {
+      sDST(0,j) = 1.0;
     }
   } 
 
@@ -134,7 +131,7 @@ void uris_meanp(ComMod& com_mod, CmMod& cm_mod, const int iUris, const SolutionS
 
   //  If the uris has passed the closing state
   if (uris_obj.cnt > uris_obj.DxClose.nrows()) {
-    if (uris_obj.meanPD > uris_obj.meanPU) {
+    if (uris_obj.meanPU > uris_obj.meanPD) {
       uris_obj.cnt = 1;
       uris_obj.clsFlg = false;
       com_mod.urisActFlag = true;
@@ -173,13 +170,8 @@ void uris_meanv(ComMod& com_mod, CmMod& cm_mod, const int iUris, const SolutionS
   auto& uris_obj = uris[iUris];
 
   const int nsd = com_mod.nsd;
-  // const int cEq = com_mod.cEq;
 
-  // auto& An = com_mod.An;
-  // auto& Ad = com_mod.Ad;
-  // auto& Dn = com_mod.Dn;
-
-  // Let's compute the neighboring region below the valve normal. When
+  // Compute the neighboring region with negative sdf distance. When
   // the valve is open, this region should roughly be valve oriface.
   int iEq = 0;
 
@@ -190,8 +182,6 @@ void uris_meanv(ComMod& com_mod, CmMod& cm_mod, const int iUris, const SolutionS
 
   for (int i = 0; i < com_mod.tnNo; i++) {
     if (uris_obj.sdf(i) <= -Deps) {
-    // Reverse the sdf distance for aortic valve
-    // if (uris_obj.sdf(i) >= Deps) {
       sImm(0,i) = 1.0;
     }
   }
@@ -205,7 +195,6 @@ void uris_meanv(ComMod& com_mod, CmMod& cm_mod, const int iUris, const SolutionS
   
   int m = nsd;
   int s = eq[iEq].s;
-  // int e = s + m - 1;
 
   Array<double> tmpV(maxNSD, com_mod.tnNo);
   for (int i = 0; i < nsd; i++) {
@@ -610,6 +599,7 @@ void uris_read_msh(Simulation* simulation) {
     // the fluid node is far away from the valve. 
     uris_obj.sdf_default = param->close_thickness() * 1e6;
     uris_obj.clsFlg = param->valve_starts_as_closed();
+    uris_obj.invert_normal = param->invert_normal();
 
     // uris_obj.tnNo = 0;
     for (int iM = 0; iM < uris_obj.nFa; iM++) {
@@ -1064,10 +1054,11 @@ void uris_calc_sdf(ComMod& com_mod) {
       int Ec = -1;
       int jM = -1;
       Vector<double> xb(nsd);
+      Vector<double> unitNormal(nsd);
       uris_find_closest_face_centroid(uris_obj, xp, nsd, minS, Ec, jM);
 
       // Compute the element normal contribution for sign
-      auto dotp = uris_compute_face_dotp(uris_obj, nsd, jM, Ec, xp, xXi, lX, xb);
+      auto dotp = uris_compute_face_dotp(uris_obj, nsd, jM, Ec, xp, xXi, lX, xb, unitNormal);
 
       double sdf_sign = uris_compute_sdf_sign(uris_obj, xp, xb, dotp);
 
@@ -1242,7 +1233,7 @@ void uris_find_closest_face_centroid(const urisType& uris_obj, const Vector<doub
 /// @brief Compute centroid and signed distance projection along local face normal.
 double uris_compute_face_dotp(const urisType& uris_obj, const int nsd, const int jM,
                               const int Ec, const Vector<double>& xp, Array<double>& xXi, 
-                              Array<double>& lX, Vector<double>& xb) {
+                              Array<double>& lX, Vector<double>& xb, Vector<double>& unitNormal) {
   #define n_dbg_uris_compute_face_dotp
   #ifdef dbg_uris_compute_face_dotp
     DebugMsg dmsg(__func__, 0);
@@ -1268,10 +1259,14 @@ double uris_compute_face_dotp(const urisType& uris_obj, const int nsd, const int
     }
   }
 
-  auto nV = utils::cross(xXi);
-  auto Jac = sqrt(utils::norm(nV));
-  nV = nV / Jac;
-  return utils::norm(xp-xb, nV);
+  unitNormal = utils::cross(xXi);
+  auto Jac = sqrt(utils::norm(unitNormal));
+  if (uris_obj.invert_normal) {
+    unitNormal = -unitNormal / Jac;
+  } else {
+    unitNormal = unitNormal / Jac;
+  }
+  return utils::norm(xp-xb, unitNormal);
 }
 
 /// @brief Compute SDF sign for open/closed URIS states.

--- a/Code/Source/solver/uris.cpp
+++ b/Code/Source/solver/uris.cpp
@@ -64,7 +64,7 @@ void uris_meanp(ComMod& com_mod, CmMod& cm_mod, const int iUris, const SolutionS
   // outside resistance region
   Array<double> sUPS(1, com_mod.tnNo);
   sUPS = 0.0;
-  for (size_t j = 0; j < com_mod.tnNo; j++) {
+  for (int j = 0; j < com_mod.tnNo; j++) {
     double sdf_j = uris_obj.sdf(j);
     if (sdf_j >= -Deps && sdf_j <= -uris_obj.sdf_deps_close) {
         sUPS(0,j) = 1.0;

--- a/Code/Source/solver/uris.cpp
+++ b/Code/Source/solver/uris.cpp
@@ -954,8 +954,6 @@ void uris_calc_sdf(ComMod& com_mod) {
     uris_build_fluid_node_mask(com_mod);
   }
 
-  Array<double> xXi(nsd, nsd-1);
-
   for (int iUris = 0; iUris < nUris; iUris++) {
     // We need to check if the valve needs to move 
     auto& uris_obj = uris[iUris];
@@ -978,15 +976,6 @@ void uris_calc_sdf(ComMod& com_mod) {
     
     if (uris_obj.sdf.size() > 0 && cnt < uris_obj.cnt) {continue;}
 
-    int max_eNoN = 0;
-    for (int iM = 0; iM < uris_obj.nFa; iM++) {
-      auto& mesh = uris_obj.msh[iM];
-      if (mesh.eNoN > max_eNoN) {
-        max_eNoN = mesh.eNoN;
-      }
-    }
-
-    Array<double> lX(nsd, max_eNoN);
     if (uris_obj.sdf.size() <= 0) {
       uris_obj.sdf.resize(com_mod.tnNo);
       uris_obj.sdf = 0.0;
@@ -1055,11 +1044,9 @@ void uris_calc_sdf(ComMod& com_mod) {
       int jM = -1;
       Vector<double> xb(nsd);
       Vector<double> unitNormal(nsd);
-      uris_find_closest_face_centroid(uris_obj, xp, nsd, minS, Ec, jM);
-
-      // Compute the element normal contribution for sign
-      auto dotp = uris_compute_face_dotp(uris_obj, nsd, jM, Ec, xp, xXi, lX, xb, unitNormal);
-
+      uris_find_closest_face_centroid(uris_obj, xp, nsd, minS, Ec, jM, xb);
+      uris_face_unit_normal(uris_obj, nsd, jM, Ec, unitNormal);
+      const double dotp = utils::norm(xp - xb, unitNormal);
       double sdf_sign = uris_compute_sdf_sign(uris_obj, xp, xb, dotp);
 
       uris_obj.sdf[ca] = sdf_sign * minS;
@@ -1198,75 +1185,80 @@ bool same_side(const Vector<double>& v1, const Vector<double>& v2,
   return sameside;
 }
 
-/// @brief Find the closest URIS face centroid to a point.
+/// @brief Barycenter of URIS surface/shell element (jM, Ec) in current valve coordinates uris_obj.x.
+void surface_element_barycenter(const urisType& uris_obj, int jM, int Ec, Vector<double>& xb) {
+  const auto& mesh = uris_obj.msh[jM];
+  xb = 0.0;
+  for (int a = 0; a < mesh.eNoN; a++) {
+    const int Ac = mesh.IEN(a, Ec);
+    xb = xb + uris_obj.x.rcol(Ac);
+  }
+  xb = xb / mesh.eNoN;
+}
+
+/// @brief Find the closest URIS shell-element centroid to xp; writes that centroid to xb.
 void uris_find_closest_face_centroid(const urisType& uris_obj, const Vector<double>& xp,
-                                     const int nsd, double& minS, int& Ec, int& jM) {
+                                     const int nsd, double& minS, int& Ec, int& jM,
+                                     Vector<double>& xb) {
   #define n_dbg_uris_find_closest_face_centroid
   #ifdef dbg_uris_find_closest_face_centroid
-    DebugMsg dmsg(__func__, 0);
-    dmsg.banner();
-    dmsg << "finding closest face centroid";
+  DebugMsg dmsg(__func__, 0);
+  dmsg.banner();
+  dmsg << "finding closest face centroid";
   #endif
 
-  Vector<double> xb(nsd);
+  Vector<double> face_centroid(nsd);
   for (int iM = 0; iM < uris_obj.nFa; iM++) {
     const auto& mesh = uris_obj.msh[iM];
     for (int e = 0; e < mesh.nEl; e++) {
-      xb = 0.0;
-      for (int a = 0; a < mesh.eNoN; a++) {
-        const int Ac = mesh.IEN(a,e);
-        xb = xb + uris_obj.x.rcol(Ac);
-      }
-      xb = xb / mesh.eNoN;
-
-      const double dS = std::sqrt((xp - xb) * (xp - xb));
-
+      surface_element_barycenter(uris_obj, iM, e, face_centroid);
+      const double dS = std::sqrt((xp - face_centroid) * (xp - face_centroid));
       if (dS < minS) {
         minS = dS;
         Ec = e;
         jM = iM;
+        xb = face_centroid;
       }
     }
   }
 }
 
-/// @brief Compute centroid and signed distance projection along local face normal.
-double uris_compute_face_dotp(const urisType& uris_obj, const int nsd, const int jM,
-                              const int Ec, const Vector<double>& xp, Array<double>& xXi, 
-                              Array<double>& lX, Vector<double>& xb, Vector<double>& unitNormal) {
-  #define n_dbg_uris_compute_face_dotp
-  #ifdef dbg_uris_compute_face_dotp
-    DebugMsg dmsg(__func__, 0);
-    dmsg.banner();
-    dmsg << "computing face dot product";
+/// @brief Unit normal of URIS face element (jM, Ec) from parametric tangents 
+/// (optionally flipped by uris_obj.invert_normal).
+void uris_face_unit_normal(const urisType& uris_obj, const int nsd, const int jM, const int Ec,
+                                 Vector<double>& unitNormal) {
+  #define n_dbg_uris_face_unit_normal
+  #ifdef dbg_uris_face_unit_normal
+  DebugMsg dmsg(__func__, 0);
+  dmsg.banner();
+  dmsg << "computing URIS face unit normal";
   #endif
 
   const auto& mesh = uris_obj.msh[jM];
+  Array<double> xXi(nsd, nsd - 1);
+  Array<double> lX(nsd, mesh.eNoN);
+
   xXi = 0.0;
   lX = 0.0;
-  xb = 0.0;
 
   for (int a = 0; a < mesh.eNoN; a++) {
-    int Ac = mesh.IEN(a,Ec);
-    xb = xb + uris_obj.x.rcol(Ac);
+    const int Ac = mesh.IEN(a, Ec);
     lX.rcol(a) = uris_obj.x.rcol(Ac);
   }
-  xb = xb / mesh.eNoN;
 
   for (int a = 0; a < mesh.eNoN; a++) {
     for (int i = 0; i < nsd - 1; i++) {
-      xXi.rcol(i) = xXi.rcol(i) + lX.rcol(a) * mesh.Nx(i,a,0);
+      xXi.rcol(i) = xXi.rcol(i) + lX.rcol(a) * mesh.Nx(i, a, 0);
     }
   }
 
   unitNormal = utils::cross(xXi);
-  auto Jac = sqrt(utils::norm(unitNormal));
+  const auto Jac = sqrt(utils::norm(unitNormal));
   if (uris_obj.invert_normal) {
     unitNormal = -unitNormal / Jac;
   } else {
     unitNormal = unitNormal / Jac;
   }
-  return utils::norm(xp-xb, unitNormal);
 }
 
 /// @brief Compute SDF sign for open/closed URIS states.
@@ -1287,5 +1279,6 @@ double uris_compute_sdf_sign(const urisType& uris_obj, const Vector<double>& xp,
     return (dot_nrm < 0.0 && dotP < 0.0) ? -1.0 : 1.0;
   }
   return (dotP < 0.0) ? -1.0 : 1.0;
-  }
+}
+
 }

--- a/Code/Source/solver/uris.cpp
+++ b/Code/Source/solver/uris.cpp
@@ -42,10 +42,14 @@ void uris_meanp(ComMod& com_mod, CmMod& cm_mod, const int iUris, const SolutionS
 
   // Compute the mean pressure in the upstream and downstream regions of the fluid mesh 
 
+  // Dimensionless factor scaling sdf_deps_close to set the outer signed distance limit 
+  // of the upstream/downstream fluid bands used for mean pressure computation.
+  double sdf_region_factor = 5.0; 
+
   // Set the limit of the upstream and downstream regions to 5 times the closed 
   // valve thickness. This should give a reasonable range for the upstream and 
   // downstream regions.
-  double Deps = uris_obj.sdf_deps_close * 5.0;
+  double Deps = uris_obj.sdf_deps_close * sdf_region_factor;
   double volU = 0.0;
   double volD = 0.0;
 
@@ -819,7 +823,7 @@ void uris_write_vtus(ComMod& com_mod) {
     for (int iM = 0; iM < uris_obj.nFa; iM++) {
       auto& mesh = uris_obj.msh[iM];
       int cOut = 0;
-      outS(cOut) = 0; // [HZ] Need to check this if it's 1 or 0
+      outS(cOut) = 0;
       outS(cOut+1) = nsd;
       // outNames[cOut] = "";
 

--- a/Code/Source/solver/uris.cpp
+++ b/Code/Source/solver/uris.cpp
@@ -171,8 +171,9 @@ void uris_meanv(ComMod& com_mod, CmMod& cm_mod, const int iUris, const SolutionS
 
   const int nsd = com_mod.nsd;
 
-  // Compute the neighboring region with negative sdf distance. When
-  // the valve is open, this region should roughly be valve oriface.
+  // Compute the neighboring region with negative sdf within the 
+  // valve's bounding box. When the valve is open, this region 
+  // should roughly be valve orifice.
   int iEq = 0;
 
   double Deps = uris_obj.sdf_deps;

--- a/Code/Source/solver/uris.cpp
+++ b/Code/Source/solver/uris.cpp
@@ -49,16 +49,16 @@ void uris_meanp(ComMod& com_mod, CmMod& cm_mod, const int iUris, const SolutionS
   // Set the limit of the upstream and downstream regions to 5 times the closed 
   // valve thickness. This should give a reasonable range for the upstream and 
   // downstream regions.
-  double Deps = uris_obj.sdf_deps_close * sdf_region_factor;
+  double meanp_sdf_outer_limit = uris_obj.sdf_deps_close * sdf_region_factor;
   double volU = 0.0;
   double volD = 0.0;
 
-  if (cm.mas(cm_mod)) {
-    std::cout << "Computing upstream region from SDF -" << Deps << " to -" 
-              << uris_obj.sdf_deps_close << " for: " << uris_obj.name << std::endl;
-    std::cout << "Computing downstream region from SDF " << uris_obj.sdf_deps_close 
-              << " to " << Deps << " for: " << uris_obj.name << std::endl;
-  }
+  // if (cm.mas(cm_mod)) {
+  //   std::cout << "Computing upstream region from SDF -" << meanp_sdf_outer_limit << " to -" 
+  //             << uris_obj.sdf_deps_close << " for: " << uris_obj.name << std::endl;
+  //   std::cout << "Computing downstream region from SDF " << uris_obj.sdf_deps_close 
+  //             << " to " << meanp_sdf_outer_limit << " for: " << uris_obj.name << std::endl;
+  // }
 
   // Compute the upstream region: negative sdf side (opposite to valve normal), 
   // outside resistance region
@@ -66,7 +66,7 @@ void uris_meanp(ComMod& com_mod, CmMod& cm_mod, const int iUris, const SolutionS
   sUPS = 0.0;
   for (int j = 0; j < com_mod.tnNo; j++) {
     double sdf_j = uris_obj.sdf(j);
-    if (sdf_j >= -Deps && sdf_j <= -uris_obj.sdf_deps_close) {
+    if (sdf_j >= -meanp_sdf_outer_limit && sdf_j <= -uris_obj.sdf_deps_close) {
         sUPS(0,j) = 1.0;
     }
   }
@@ -81,7 +81,7 @@ void uris_meanp(ComMod& com_mod, CmMod& cm_mod, const int iUris, const SolutionS
   sDST = 0.0;
   for (size_t j = 0; j < com_mod.tnNo; j++) {
     double sdf_j = uris_obj.sdf(j);
-    if (sdf_j >= uris_obj.sdf_deps_close && sdf_j <= Deps) {
+    if (sdf_j >= uris_obj.sdf_deps_close && sdf_j <= meanp_sdf_outer_limit) {
       sDST(0,j) = 1.0;
     }
   } 

--- a/Code/Source/solver/uris.h
+++ b/Code/Source/solver/uris.h
@@ -33,12 +33,13 @@ bool in_poly(const Vector<double>& P, const Array<double>& P1, bool include_bdry
 bool same_side(const Vector<double>& v1, const Vector<double>& v2, const Vector<double>& v3,
               const Vector<double>& v4, const Vector<double>& p, bool include_bdry);
 
-void uris_find_closest_face_centroid(const urisType& uris_obj, const Vector<double>& xp,
-  const int nsd, double& minS, int& Ec, int& jM);
+void surface_element_barycenter(const urisType& uris_obj, int jM, int Ec, Vector<double>& xb);
 
-double uris_compute_face_dotp(const urisType& uris_obj, const int nsd, const int jM,
-  const int Ec, const Vector<double>& xp, Array<double>& xXi, Array<double>& lX, 
-  Vector<double>& xb, Vector<double>& unitNormal);
+void uris_find_closest_face_centroid(const urisType& uris_obj, const Vector<double>& xp,
+  const int nsd, double& minS, int& Ec, int& jM, Vector<double>& xb);
+
+void uris_face_unit_normal(const urisType& uris_obj, const int nsd, const int jM, const int Ec,
+  Vector<double>& unitNormal);
 
 double uris_compute_sdf_sign(const urisType& uris_obj, const Vector<double>& xp,
   const Vector<double>& xb, const double dotP);

--- a/Code/Source/solver/uris.h
+++ b/Code/Source/solver/uris.h
@@ -37,7 +37,8 @@ void uris_find_closest_face_centroid(const urisType& uris_obj, const Vector<doub
   const int nsd, double& minS, int& Ec, int& jM);
 
 double uris_compute_face_dotp(const urisType& uris_obj, const int nsd, const int jM,
-  const int Ec, const Vector<double>& xp, Array<double>& xXi, Array<double>& lX, Vector<double>& xb);
+  const int Ec, const Vector<double>& xp, Array<double>& xXi, Array<double>& lX, 
+  Vector<double>& xb, Vector<double>& unitNormal);
 
 double uris_compute_sdf_sign(const urisType& uris_obj, const Vector<double>& xp,
   const Vector<double>& xb, const double dotP);

--- a/tests/cases/uris/pipe_uris_cfd/solver.xml
+++ b/tests/cases/uris/pipe_uris_cfd/solver.xml
@@ -60,6 +60,7 @@
   <Closed_thickness> 0.2 </Closed_thickness>
   <Resistance> 1.0e5 </Resistance>
   <Closed_resistance> 1.0e5 </Closed_resistance>
+  <Invert_normal> false </Invert_normal>
   <Positive_flow_normal_file_path> meshes/normal.dat </Positive_flow_normal_file_path>
 </Add_URIS_mesh>
 
@@ -84,6 +85,7 @@
   <Closed_thickness> 0.2 </Closed_thickness>
   <Resistance> 1.0e5 </Resistance>
   <Closed_resistance> 1.0e5 </Closed_resistance>
+  <Invert_normal> false </Invert_normal>
   <Positive_flow_normal_file_path> meshes/normal.dat </Positive_flow_normal_file_path>
 </Add_URIS_mesh>
 

--- a/tests/cases/uris/pipe_uris_fsi/solver.xml
+++ b/tests/cases/uris/pipe_uris_fsi/solver.xml
@@ -82,6 +82,7 @@
   <Closed_thickness> 0.2 </Closed_thickness>
   <Resistance> 1.0e5 </Resistance>
   <Closed_resistance> 1.0e5 </Closed_resistance>
+  <Invert_normal> false </Invert_normal>
   <Positive_flow_normal_file_path> meshes/normal.dat </Positive_flow_normal_file_path>
 </Add_URIS_mesh>
 
@@ -106,6 +107,7 @@
   <Closed_thickness> 0.2 </Closed_thickness>
   <Resistance> 1.0e5 </Resistance>
   <Closed_resistance> 1.0e5 </Closed_resistance>
+  <Invert_normal> false </Invert_normal>
   <Positive_flow_normal_file_path> meshes/normal.dat </Positive_flow_normal_file_path>
 </Add_URIS_mesh>
 


### PR DESCRIPTION
Resolves https://github.com/SimVascular/svMultiPhysics/issues/542

## Release Notes 
* Swapped the RIS valve upstream and downstream direction
* Updated mean pressure integration domain for the RIS valve until half-thickness
* Added an optional argument to invert the RIS valve surface normal direction

## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
