### PR TITLE
More accurate naming of norm functions

### DIFF
--- a/Code/Source/solver/CoupledBoundaryCondition.cpp
+++ b/Code/Source/solver/CoupledBoundaryCondition.cpp
@@ -1081,7 +1081,7 @@ std::pair<double, Vector<double>> CappingSurface::compute_jacobian_and_normal(co
     double Jac = 0.0;
     Vector<double> n(cap_nsd_);
     n = utils::cross(xXi);
-    Jac = sqrt(utils::norm(n));
+    Jac = sqrt(utils::norm_squared(n));
 
     if (utils::is_zero(Jac)) {
         throw CappingSurfaceBaseException("[CappingSurface::compute_jacobian_and_normal] Zero Jacobian at Gauss point " +
@@ -1098,7 +1098,7 @@ std::pair<double, Vector<double>> CappingSurface::compute_jacobian_and_normal(co
             n0(i) = normals_(i, e);
         }
 
-        double n0_norm = sqrt(utils::norm(n0));
+        double n0_norm = sqrt(utils::norm_squared(n0));
         if (!utils::is_zero(n0_norm)) {
             n0 = n0 / n0_norm;
 

--- a/Code/Source/solver/CoupledBoundaryCondition.cpp
+++ b/Code/Source/solver/CoupledBoundaryCondition.cpp
@@ -1081,7 +1081,7 @@ std::pair<double, Vector<double>> CappingSurface::compute_jacobian_and_normal(co
     double Jac = 0.0;
     Vector<double> n(cap_nsd_);
     n = utils::cross(xXi);
-    Jac = sqrt(utils::norm_squared(n));
+    Jac = utils::norm(n);
 
     if (utils::is_zero(Jac)) {
         throw CappingSurfaceBaseException("[CappingSurface::compute_jacobian_and_normal] Zero Jacobian at Gauss point " +
@@ -1098,7 +1098,7 @@ std::pair<double, Vector<double>> CappingSurface::compute_jacobian_and_normal(co
             n0(i) = normals_(i, e);
         }
 
-        double n0_norm = sqrt(utils::norm_squared(n0));
+        double n0_norm = utils::norm(n0);
         if (!utils::is_zero(n0_norm)) {
             n0 = n0 / n0_norm;
 

--- a/Code/Source/solver/all_fun.cpp
+++ b/Code/Source/solver/all_fun.cpp
@@ -391,7 +391,7 @@ double integ(const ComMod& com_mod, const CmMod& cm_mod, int iM, const Array<dou
         if (msh.lShl) {
           Vector<double> nV(nsd);
           nn::gnns(nsd, eNoN, Nxi, xl, nV, tmps, tmps);
-          Jac  = sqrt(utils::norm_squared(nV));
+          Jac  = utils::norm(nV);
         } else { 
           nn::gnn(eNoN, nsd, insd, Nxi, xl, Nx, Jac, tmp);
         }
@@ -572,7 +572,7 @@ double integ(const ComMod& com_mod, const CmMod& cm_mod, int dId, const Array<do
             sl(a) = s(l,Ac);
           } else { 
             auto rows = s.col(Ac, {l,u});
-            sl(a) = sqrt(utils::norm_squared(rows));
+            sl(a) = utils::norm(rows);
           }
           ibl = ibl + com_mod.iblank(Ac);
         }
@@ -590,7 +590,7 @@ double integ(const ComMod& com_mod, const CmMod& cm_mod, int dId, const Array<do
             if (msh.lShl) {
               Vector<double> nV(nsd);
               nn::gnns(nsd, eNoN, Nxi, xl, nV, tmps, tmps);
-              Jac  = sqrt(utils::norm_squared(nV));
+              Jac  = utils::norm(nV);
             } else { 
               nn::gnn(eNoN, nsd, insd, Nxi, xl, Nx, Jac, tmp);
             }
@@ -646,7 +646,7 @@ double integ(const ComMod& com_mod, const CmMod& cm_mod, int dId, const Array<do
             sl(a) = s(l,Ac);
           } else { 
             auto rows = s.col(Ac, {l,u});
-            sl(a) = sqrt(utils::norm_squared(rows));
+            sl(a) = utils::norm(rows);
           }
         }
 
@@ -815,7 +815,7 @@ double integ(const ComMod& com_mod, const CmMod& cm_mod, const faceType& lFa, co
       }
 
       // Calculating the Jacobian (encodes area of face element)
-      double Jac = sqrt(utils::norm_squared(n));
+      double Jac = utils::norm(n);
 
       // Calculating the function value at Gauss point
       double sHat = 0.0;

--- a/Code/Source/solver/all_fun.cpp
+++ b/Code/Source/solver/all_fun.cpp
@@ -391,7 +391,7 @@ double integ(const ComMod& com_mod, const CmMod& cm_mod, int iM, const Array<dou
         if (msh.lShl) {
           Vector<double> nV(nsd);
           nn::gnns(nsd, eNoN, Nxi, xl, nV, tmps, tmps);
-          Jac  = sqrt(utils::norm(nV));
+          Jac  = sqrt(utils::norm_squared(nV));
         } else { 
           nn::gnn(eNoN, nsd, insd, Nxi, xl, Nx, Jac, tmp);
         }
@@ -572,7 +572,7 @@ double integ(const ComMod& com_mod, const CmMod& cm_mod, int dId, const Array<do
             sl(a) = s(l,Ac);
           } else { 
             auto rows = s.col(Ac, {l,u});
-            sl(a) = sqrt(utils::norm(rows));
+            sl(a) = sqrt(utils::norm_squared(rows));
           }
           ibl = ibl + com_mod.iblank(Ac);
         }
@@ -590,7 +590,7 @@ double integ(const ComMod& com_mod, const CmMod& cm_mod, int dId, const Array<do
             if (msh.lShl) {
               Vector<double> nV(nsd);
               nn::gnns(nsd, eNoN, Nxi, xl, nV, tmps, tmps);
-              Jac  = sqrt(utils::norm(nV));
+              Jac  = sqrt(utils::norm_squared(nV));
             } else { 
               nn::gnn(eNoN, nsd, insd, Nxi, xl, Nx, Jac, tmp);
             }
@@ -646,7 +646,7 @@ double integ(const ComMod& com_mod, const CmMod& cm_mod, int dId, const Array<do
             sl(a) = s(l,Ac);
           } else { 
             auto rows = s.col(Ac, {l,u});
-            sl(a) = sqrt(utils::norm(rows));
+            sl(a) = sqrt(utils::norm_squared(rows));
           }
         }
 
@@ -815,7 +815,7 @@ double integ(const ComMod& com_mod, const CmMod& cm_mod, const faceType& lFa, co
       }
 
       // Calculating the Jacobian (encodes area of face element)
-      double Jac = sqrt(utils::norm(n));
+      double Jac = sqrt(utils::norm_squared(n));
 
       // Calculating the function value at Gauss point
       double sHat = 0.0;

--- a/Code/Source/solver/baf_ini.cpp
+++ b/Code/Source/solver/baf_ini.cpp
@@ -393,7 +393,7 @@ void bc_ini(const ComMod& com_mod, const CmMod& cm_mod, bcType& lBc, faceType& l
        for (int i = 0; i < sV.nrows(); i++) {
          sV(i,a) = sV(i,a) - center(i);
        }
-       sVl.set_col(a, sV.col(a) / sqrt(norm_squared(sV.col(a))));
+       sVl.set_col(a, sV.col(a) / norm(sV.col(a)));
      }
 
      // "s" is going to keep the ew.e value
@@ -681,7 +681,7 @@ void face_ini(Simulation* simulation, mshType& lM, faceType& lFa, const Solution
   for (int a = 0; a < lFa.nNo; a++) {
     int Ac = lFa.gN(a);
     auto sV_col = sV.col(Ac);
-    double sln = sqrt(utils::norm_squared(sV_col));
+    double sln = utils::norm(sV_col);
 
     if (utils::is_zero(sln)) {
       if (flag) {
@@ -1014,7 +1014,7 @@ void shl_ini(const ComMod& com_mod, const CmMod& cm_mod, mshType& lM)
       Array<double> tmpR(nsd,nsd-1);
       auto Nxi = lM.Nx.slice(g);
       nn::gnns(nsd, eNoN, Nxi, xl, nV, tmpR, tmpR);
-      double Jac = sqrt(norm_squared(nV));
+      double Jac = norm(nV);
 
       for (int a = 0; a < eNoN; a++) {
         int Ac = lM.IEN(a,e);
@@ -1032,7 +1032,7 @@ void shl_ini(const ComMod& com_mod, const CmMod& cm_mod, mshType& lM)
 
   for (int a = 0; a < nNo; a++) {
     int Ac = lM.gN(a);
-    double Jac = sqrt(norm_squared(sV.col(Ac)));
+    double Jac = norm(sV.col(Ac));
 
     if (is_zero(Jac)) {
       if (flag) {

--- a/Code/Source/solver/baf_ini.cpp
+++ b/Code/Source/solver/baf_ini.cpp
@@ -401,10 +401,10 @@ void bc_ini(const ComMod& com_mod, const CmMod& cm_mod, bcType& lBc, faceType& l
      for (int a = 0; a < lFa.nNo; a++) {
        int Ac = lFa.gN(a);
        auto nV = com_mod.x.col(Ac) - center;
-       double maxN = norm_squared(nV, sVl.col(0));
+       double maxN = dot(nV, sVl.col(0));
        int i = 0;
        for (int b = 1; b < j; b++) {
-         double tmp = norm_squared(nV, sVl.col(b));
+         double tmp = dot(nV, sVl.col(b));
          if (tmp > maxN) {
            maxN = tmp;
            i = b;
@@ -621,7 +621,7 @@ void face_ini(Simulation* simulation, mshType& lM, faceType& lFa, const Solution
           v(i)  = xl(i,a) - xl(i,b);
         }
 
-        if (utils::norm_squared(nV,v) < 0.0) {
+        if (utils::dot(nV,v) < 0.0) {
           nV = -nV;
          }
 

--- a/Code/Source/solver/baf_ini.cpp
+++ b/Code/Source/solver/baf_ini.cpp
@@ -393,7 +393,7 @@ void bc_ini(const ComMod& com_mod, const CmMod& cm_mod, bcType& lBc, faceType& l
        for (int i = 0; i < sV.nrows(); i++) {
          sV(i,a) = sV(i,a) - center(i);
        }
-       sVl.set_col(a, sV.col(a) / sqrt(norm(sV.col(a))));
+       sVl.set_col(a, sV.col(a) / sqrt(norm_squared(sV.col(a))));
      }
 
      // "s" is going to keep the ew.e value
@@ -401,16 +401,16 @@ void bc_ini(const ComMod& com_mod, const CmMod& cm_mod, bcType& lBc, faceType& l
      for (int a = 0; a < lFa.nNo; a++) {
        int Ac = lFa.gN(a);
        auto nV = com_mod.x.col(Ac) - center;
-       double maxN = norm(nV, sVl.col(0));
+       double maxN = norm_squared(nV, sVl.col(0));
        int i = 0;
        for (int b = 1; b < j; b++) {
-         double tmp = norm(nV, sVl.col(b));
+         double tmp = norm_squared(nV, sVl.col(b));
          if (tmp > maxN) {
            maxN = tmp;
            i = b;
          }
        }
-       s(Ac) = 1.0 - norm(nV) / norm(sV.col(i));
+       s(Ac) = 1.0 - norm_squared(nV) / norm_squared(sV.col(i));
      }
 
   } else if (btest(lBc.bType, enum_int(BoundaryConditionType::bType_ud))) { 
@@ -621,7 +621,7 @@ void face_ini(Simulation* simulation, mshType& lM, faceType& lFa, const Solution
           v(i)  = xl(i,a) - xl(i,b);
         }
 
-        if (utils::norm(nV,v) < 0.0) {
+        if (utils::norm_squared(nV,v) < 0.0) {
           nV = -nV;
          }
 
@@ -681,7 +681,7 @@ void face_ini(Simulation* simulation, mshType& lM, faceType& lFa, const Solution
   for (int a = 0; a < lFa.nNo; a++) {
     int Ac = lFa.gN(a);
     auto sV_col = sV.col(Ac);
-    double sln = sqrt(utils::norm(sV_col));
+    double sln = sqrt(utils::norm_squared(sV_col));
 
     if (utils::is_zero(sln)) {
       if (flag) {
@@ -1014,7 +1014,7 @@ void shl_ini(const ComMod& com_mod, const CmMod& cm_mod, mshType& lM)
       Array<double> tmpR(nsd,nsd-1);
       auto Nxi = lM.Nx.slice(g);
       nn::gnns(nsd, eNoN, Nxi, xl, nV, tmpR, tmpR);
-      double Jac = sqrt(norm(nV));
+      double Jac = sqrt(norm_squared(nV));
 
       for (int a = 0; a < eNoN; a++) {
         int Ac = lM.IEN(a,e);
@@ -1032,7 +1032,7 @@ void shl_ini(const ComMod& com_mod, const CmMod& cm_mod, mshType& lM)
 
   for (int a = 0; a < nNo; a++) {
     int Ac = lM.gN(a);
-    double Jac = sqrt(norm(sV.col(Ac)));
+    double Jac = sqrt(norm_squared(sV.col(Ac)));
 
     if (is_zero(Jac)) {
       if (flag) {

--- a/Code/Source/solver/baf_ini.cpp
+++ b/Code/Source/solver/baf_ini.cpp
@@ -401,10 +401,10 @@ void bc_ini(const ComMod& com_mod, const CmMod& cm_mod, bcType& lBc, faceType& l
      for (int a = 0; a < lFa.nNo; a++) {
        int Ac = lFa.gN(a);
        auto nV = com_mod.x.col(Ac) - center;
-       double maxN = dot(nV, sVl.col(0));
+       double maxN = nV * sVl.rcol(0);
        int i = 0;
        for (int b = 1; b < j; b++) {
-         double tmp = dot(nV, sVl.col(b));
+         const double tmp = nV * sVl.rcol(b);
          if (tmp > maxN) {
            maxN = tmp;
            i = b;
@@ -621,9 +621,9 @@ void face_ini(Simulation* simulation, mshType& lM, faceType& lFa, const Solution
           v(i)  = xl(i,a) - xl(i,b);
         }
 
-        if (utils::dot(nV,v) < 0.0) {
+        if (nV * v < 0.0) {
           nV = -nV;
-         }
+        }
 
         for (int a = 0; a < fs.eNoN; a++) {
           int Ac = lFa.IEN(a,e);

--- a/Code/Source/solver/cep.cpp
+++ b/Code/Source/solver/cep.cpp
@@ -167,7 +167,7 @@ void cep_2d(ComMod& com_mod, CepMod& cep_mod, const int eNoN, const int nFn, con
 
     // Compute fiber stretch
     for (int i = 0; i < nFn; i++) {
-      Ls(i) = sqrt(utils::dot(fN.col(i), mat_mul(C, fN.col(i))));
+      Ls(i) = sqrt(fN.rcol(i) * mat_mul(C, fN.rcol(i)));
       for (int j = 0; j < 2; j++) {
         fl(j,i) = fN(j,i) / Ls(i);
       }
@@ -320,7 +320,7 @@ void cep_3d(ComMod& com_mod, CepMod& cep_mod, const int eNoN, const int nFn, con
 
     // Compute fiber stretch
     for (int i = 0; i < nFn; i++) {
-      Ls(i) = sqrt(utils::dot(fN.col(i), mat_mul(C, fN.col(i))));
+      Ls(i) = sqrt(fN.rcol(i) * mat_mul(C, fN.rcol(i)));
       for (int j = 0; j < 3; j++) {
         fl(j,i) = fN(j,i) / Ls(i);
       }

--- a/Code/Source/solver/cep.cpp
+++ b/Code/Source/solver/cep.cpp
@@ -167,7 +167,7 @@ void cep_2d(ComMod& com_mod, CepMod& cep_mod, const int eNoN, const int nFn, con
 
     // Compute fiber stretch
     for (int i = 0; i < nFn; i++) {
-      Ls(i) = sqrt(utils::norm(fN.col(i), mat_mul(C, fN.col(i))));
+      Ls(i) = sqrt(utils::norm_squared(fN.col(i), mat_mul(C, fN.col(i))));
       for (int j = 0; j < 2; j++) {
         fl(j,i) = fN(j,i) / Ls(i);
       }
@@ -320,7 +320,7 @@ void cep_3d(ComMod& com_mod, CepMod& cep_mod, const int eNoN, const int nFn, con
 
     // Compute fiber stretch
     for (int i = 0; i < nFn; i++) {
-      Ls(i) = sqrt(utils::norm(fN.col(i), mat_mul(C, fN.col(i))));
+      Ls(i) = sqrt(utils::norm_squared(fN.col(i), mat_mul(C, fN.col(i))));
       for (int j = 0; j < 3; j++) {
         fl(j,i) = fN(j,i) / Ls(i);
       }

--- a/Code/Source/solver/cep.cpp
+++ b/Code/Source/solver/cep.cpp
@@ -167,7 +167,7 @@ void cep_2d(ComMod& com_mod, CepMod& cep_mod, const int eNoN, const int nFn, con
 
     // Compute fiber stretch
     for (int i = 0; i < nFn; i++) {
-      Ls(i) = sqrt(utils::norm_squared(fN.col(i), mat_mul(C, fN.col(i))));
+      Ls(i) = sqrt(utils::dot(fN.col(i), mat_mul(C, fN.col(i))));
       for (int j = 0; j < 2; j++) {
         fl(j,i) = fN(j,i) / Ls(i);
       }
@@ -320,7 +320,7 @@ void cep_3d(ComMod& com_mod, CepMod& cep_mod, const int eNoN, const int nFn, con
 
     // Compute fiber stretch
     for (int i = 0; i < nFn; i++) {
-      Ls(i) = sqrt(utils::norm_squared(fN.col(i), mat_mul(C, fN.col(i))));
+      Ls(i) = sqrt(utils::dot(fN.col(i), mat_mul(C, fN.col(i))));
       for (int j = 0; j < 3; j++) {
         fl(j,i) = fN(j,i) / Ls(i);
       }

--- a/Code/Source/solver/cmm.cpp
+++ b/Code/Source/solver/cmm.cpp
@@ -283,7 +283,7 @@ void cmm_b(ComMod& com_mod, const faceType& lFa, const int e, const Array<double
     Vector<double> nV(nsd);
     auto Nx = lFa.Nx.slice(g);
     nn::gnnb(com_mod, lFa, e, g, nsd, nsd-1, 3, Nx, nV, solutions, consts::MechanicalConfigurationType::reference);
-    double Jac = sqrt(utils::norm(nV));
+    double Jac = sqrt(utils::norm_squared(nV));
     nV = nV / Jac;
     double w = lFa.w(g)*Jac;
     auto N = lFa.N.col(g);
@@ -334,7 +334,7 @@ void bcmmi(ComMod& com_mod, const int eNoN, const int idof, const double w, cons
     }
 
   } else {
-    double wl = w * sqrt(utils::norm(nV));
+    double wl = w * sqrt(utils::norm_squared(nV));
     for (int a = 0; a < eNoN; a++) {
       lR(0,a) = lR(0,a) - wl*N(a)*tfn(0);
       lR(1,a) = lR(1,a) - wl*N(a)*tfn(1);
@@ -375,7 +375,7 @@ void cmmi(ComMod& com_mod, const mshType& lM, const Array<double>& al, const Arr
   }
 
   auto nV = utils::cross(xXi);
-  auto Jac = sqrt(utils::norm(nV));
+  auto Jac = sqrt(utils::norm_squared(nV));
   nV = nV / Jac;
 
   Array<double> lR(dof,3); 
@@ -540,13 +540,13 @@ void cmm_stiffness(ComMod& com_mod, const Array<double>& Nxi, const Array<double
   }
 
   auto nV = utils::cross(xXi);
-  double Jac = sqrt(utils::norm(nV));
+  double Jac = sqrt(utils::norm_squared(nV));
   nV = nV / Jac;
 
   //  Rotation matrix
   //
   Array<double> thet(3,3);
-  thet.set_row(0, xXi.col(0) / sqrt(utils::norm(xXi.col(0))));
+  thet.set_row(0, xXi.col(0) / sqrt(utils::norm_squared(xXi.col(0))));
   thet.set_row(2, nV);
 
   thet(1,0) = thet(2,1)*thet(0,2) - thet(2,2)*thet(0,1);

--- a/Code/Source/solver/cmm.cpp
+++ b/Code/Source/solver/cmm.cpp
@@ -283,7 +283,7 @@ void cmm_b(ComMod& com_mod, const faceType& lFa, const int e, const Array<double
     Vector<double> nV(nsd);
     auto Nx = lFa.Nx.slice(g);
     nn::gnnb(com_mod, lFa, e, g, nsd, nsd-1, 3, Nx, nV, solutions, consts::MechanicalConfigurationType::reference);
-    double Jac = sqrt(utils::norm_squared(nV));
+    double Jac = utils::norm(nV);
     nV = nV / Jac;
     double w = lFa.w(g)*Jac;
     auto N = lFa.N.col(g);
@@ -334,7 +334,7 @@ void bcmmi(ComMod& com_mod, const int eNoN, const int idof, const double w, cons
     }
 
   } else {
-    double wl = w * sqrt(utils::norm_squared(nV));
+    double wl = w * utils::norm(nV);
     for (int a = 0; a < eNoN; a++) {
       lR(0,a) = lR(0,a) - wl*N(a)*tfn(0);
       lR(1,a) = lR(1,a) - wl*N(a)*tfn(1);
@@ -375,7 +375,7 @@ void cmmi(ComMod& com_mod, const mshType& lM, const Array<double>& al, const Arr
   }
 
   auto nV = utils::cross(xXi);
-  auto Jac = sqrt(utils::norm_squared(nV));
+  auto Jac = utils::norm(nV);
   nV = nV / Jac;
 
   Array<double> lR(dof,3); 
@@ -540,13 +540,13 @@ void cmm_stiffness(ComMod& com_mod, const Array<double>& Nxi, const Array<double
   }
 
   auto nV = utils::cross(xXi);
-  double Jac = sqrt(utils::norm_squared(nV));
+  double Jac = utils::norm(nV);
   nV = nV / Jac;
 
   //  Rotation matrix
   //
   Array<double> thet(3,3);
-  thet.set_row(0, xXi.col(0) / sqrt(utils::norm_squared(xXi.col(0))));
+  thet.set_row(0, xXi.col(0) / utils::norm(xXi.col(0)));
   thet.set_row(2, nV);
 
   thet(1,0) = thet(2,1)*thet(0,2) - thet(2,2)*thet(0,1);

--- a/Code/Source/solver/contact.cpp
+++ b/Code/Source/solver/contact.cpp
@@ -222,10 +222,10 @@ void construct_contact_pnlty(ComMod& com_mod, CmMod& cm_mod, const SolutionState
 
       auto x12 = x1 - x2;
       double c = sqrt(utils::norm_squared(x12));
-      double al = sqrt(fabs(utils::norm_squared(nV1, nV2)));
+      double al = sqrt(fabs(utils::dot(nV1, nV2)));
 
       if (c <= cntctM.c && al >= cntctM.al) {
-        double d = utils::norm_squared(x12, nV2);
+        double d = utils::dot(x12, nV2);
         bool flag = false;
         double pk{0.0};
    

--- a/Code/Source/solver/contact.cpp
+++ b/Code/Source/solver/contact.cpp
@@ -79,7 +79,7 @@ void construct_contact_pnlty(ComMod& com_mod, CmMod& cm_mod, const SolutionState
 
       Vector<double> nV1(nsd);
       nn::gnns(nsd, eNoN, Nx, xl, nV1, gCov, gCnv);
-      double Jac = sqrt(utils::norm(nV1));
+      double Jac = sqrt(utils::norm_squared(nV1));
       nV1 = nV1 / Jac;
 
       for (int g = 0; g < msh.nG; g++) {
@@ -221,11 +221,11 @@ void construct_contact_pnlty(ComMod& com_mod, CmMod& cm_mod, const SolutionState
       auto nV2 = sF.rcol(Bc);
 
       auto x12 = x1 - x2;
-      double c = sqrt(utils::norm(x12));
-      double al = sqrt(fabs(utils::norm(nV1, nV2)));
+      double c = sqrt(utils::norm_squared(x12));
+      double al = sqrt(fabs(utils::norm_squared(nV1, nV2)));
 
       if (c <= cntctM.c && al >= cntctM.al) {
-        double d = utils::norm(x12, nV2);
+        double d = utils::norm_squared(x12, nV2);
         bool flag = false;
         double pk{0.0};
    

--- a/Code/Source/solver/contact.cpp
+++ b/Code/Source/solver/contact.cpp
@@ -79,7 +79,7 @@ void construct_contact_pnlty(ComMod& com_mod, CmMod& cm_mod, const SolutionState
 
       Vector<double> nV1(nsd);
       nn::gnns(nsd, eNoN, Nx, xl, nV1, gCov, gCnv);
-      double Jac = sqrt(utils::norm_squared(nV1));
+      double Jac = utils::norm(nV1);
       nV1 = nV1 / Jac;
 
       for (int g = 0; g < msh.nG; g++) {
@@ -221,7 +221,7 @@ void construct_contact_pnlty(ComMod& com_mod, CmMod& cm_mod, const SolutionState
       auto nV2 = sF.rcol(Bc);
 
       auto x12 = x1 - x2;
-      double c = sqrt(utils::norm_squared(x12));
+      double c = utils::norm(x12);
       double al = sqrt(fabs(utils::dot(nV1, nV2)));
 
       if (c <= cntctM.c && al >= cntctM.al) {

--- a/Code/Source/solver/contact.cpp
+++ b/Code/Source/solver/contact.cpp
@@ -222,10 +222,10 @@ void construct_contact_pnlty(ComMod& com_mod, CmMod& cm_mod, const SolutionState
 
       auto x12 = x1 - x2;
       double c = utils::norm(x12);
-      double al = sqrt(fabs(utils::dot(nV1, nV2)));
+      double al = sqrt(fabs(nV1 * nV2));
 
       if (c <= cntctM.c && al >= cntctM.al) {
-        double d = utils::dot(x12, nV2);
+        double d = x12 * nV2;
         bool flag = false;
         double pk{0.0};
    

--- a/Code/Source/solver/eq_assem.cpp
+++ b/Code/Source/solver/eq_assem.cpp
@@ -81,7 +81,7 @@ void b_assem_neu_bc(ComMod& com_mod, const faceType& lFa, const Vector<double>& 
       Vector<double> nV(nsd);
       auto Nx = lFa.Nx.rslice(g);
       nn::gnnb(com_mod, lFa, e, g, nsd, nsd-1, eNoN, Nx, nV, solutions, consts::MechanicalConfigurationType::reference);
-      double Jac = sqrt(utils::norm(nV));
+      double Jac = sqrt(utils::norm_squared(nV));
       nV = nV / Jac;
       double w = lFa.w(g)*Jac;
       N  = lFa.N.col(g);
@@ -251,7 +251,7 @@ void b_neu_folw_p(ComMod& com_mod, const bcType& lBc, const faceType& lFa, const
       Vector<double> nV(nsd);
       auto Nx_g = lFa.Nx.rslice(g);
       nn::gnnb(com_mod, lFa, e, g, nsd, nsd-1, eNoNb, Nx_g, nV, solutions, consts::MechanicalConfigurationType::reference);
-      Jac = sqrt(utils::norm(nV));
+      Jac = sqrt(utils::norm_squared(nV));
       nV = nV / Jac;
       double w = lFa.w(g)*Jac;
 

--- a/Code/Source/solver/eq_assem.cpp
+++ b/Code/Source/solver/eq_assem.cpp
@@ -81,7 +81,7 @@ void b_assem_neu_bc(ComMod& com_mod, const faceType& lFa, const Vector<double>& 
       Vector<double> nV(nsd);
       auto Nx = lFa.Nx.rslice(g);
       nn::gnnb(com_mod, lFa, e, g, nsd, nsd-1, eNoN, Nx, nV, solutions, consts::MechanicalConfigurationType::reference);
-      double Jac = sqrt(utils::norm_squared(nV));
+      double Jac = utils::norm(nV);
       nV = nV / Jac;
       double w = lFa.w(g)*Jac;
       N  = lFa.N.col(g);
@@ -251,7 +251,7 @@ void b_neu_folw_p(ComMod& com_mod, const bcType& lBc, const faceType& lFa, const
       Vector<double> nV(nsd);
       auto Nx_g = lFa.Nx.rslice(g);
       nn::gnnb(com_mod, lFa, e, g, nsd, nsd-1, eNoNb, Nx_g, nV, solutions, consts::MechanicalConfigurationType::reference);
-      Jac = sqrt(utils::norm_squared(nV));
+      Jac = utils::norm(nV);
       nV = nV / Jac;
       double w = lFa.w(g)*Jac;
 

--- a/Code/Source/solver/nn.cpp
+++ b/Code/Source/solver/nn.cpp
@@ -443,7 +443,7 @@ void gnn(const int eNoN, const int nsd, const int insd, Array<double>& Nxi, Arra
       }
     }
 
-    Jac = sqrt(utils::norm(xXi)) + 1.E+3*eps;
+    Jac = sqrt(utils::norm_squared(xXi)) + 1.E+3*eps;
     for (int a = 0; a < eNoN; a++) {
       Nx(0,a) = Nxi(0,a) / Jac;
     }
@@ -515,7 +515,7 @@ void gnn(const int eNoN, const int nsd, const int insd, Array<double>& Nxi, Arra
 
 /// @brief This routine returns a surface normal vector at element "e" and Gauss point
 /// 'g' of face 'lFa' that is the normal weighted by Jac, i.e.
-/// Jac = SQRT(NORM(n)), the Jacobian of the mapping from parent surface element to
+/// Jac = sqrt(norm_squared(n)), the Jacobian of the mapping from parent surface element to
 /// reference/old/new configuration.
 ///
 /// cfg denotes which configuration (reference/timestep 0, old/timestep n, or new/timestep n+1). Default reference
@@ -661,7 +661,7 @@ void gnnb(const ComMod& com_mod, const faceType& lFa, const int e, const int g, 
 
     auto v = utils::cross(xXi);
     for (int i = 0; i < nsd; i++) {
-      v(i) = v(i) / sqrt(utils::norm(v));
+      v(i) = v(i) / sqrt(utils::norm_squared(v));
     }
 
     // Face element surface deflation
@@ -692,7 +692,7 @@ void gnnb(const ComMod& com_mod, const faceType& lFa, const int e, const int g, 
       v(i) = lX(i,a) - v(i);
     }
 
-    if (utils::norm(n,v) < 0.0) {
+    if (utils::norm_squared(n,v) < 0.0) {
       n = -n;
     }
 
@@ -725,7 +725,7 @@ void gnnb(const ComMod& com_mod, const faceType& lFa, const int e, const int g, 
     v(i) = lX(i,a) - lX(i,b);
   }
 
-  if (utils::norm(n,v) < 0.0) {
+  if (utils::norm_squared(n,v) < 0.0) {
     n = -n;
   }
 }

--- a/Code/Source/solver/nn.cpp
+++ b/Code/Source/solver/nn.cpp
@@ -692,7 +692,7 @@ void gnnb(const ComMod& com_mod, const faceType& lFa, const int e, const int g, 
       v(i) = lX(i,a) - v(i);
     }
 
-    if (utils::dot(n,v) < 0.0) {
+    if (n * v < 0.0) {
       n = -n;
     }
 
@@ -725,7 +725,7 @@ void gnnb(const ComMod& com_mod, const faceType& lFa, const int e, const int g, 
     v(i) = lX(i,a) - lX(i,b);
   }
 
-  if (utils::dot(n,v) < 0.0) {
+  if (n * v < 0.0) {
     n = -n;
   }
 }

--- a/Code/Source/solver/nn.cpp
+++ b/Code/Source/solver/nn.cpp
@@ -692,7 +692,7 @@ void gnnb(const ComMod& com_mod, const faceType& lFa, const int e, const int g, 
       v(i) = lX(i,a) - v(i);
     }
 
-    if (utils::norm_squared(n,v) < 0.0) {
+    if (utils::dot(n,v) < 0.0) {
       n = -n;
     }
 
@@ -725,7 +725,7 @@ void gnnb(const ComMod& com_mod, const faceType& lFa, const int e, const int g, 
     v(i) = lX(i,a) - lX(i,b);
   }
 
-  if (utils::norm_squared(n,v) < 0.0) {
+  if (utils::dot(n,v) < 0.0) {
     n = -n;
   }
 }

--- a/Code/Source/solver/nn.cpp
+++ b/Code/Source/solver/nn.cpp
@@ -443,7 +443,7 @@ void gnn(const int eNoN, const int nsd, const int insd, Array<double>& Nxi, Arra
       }
     }
 
-    Jac = sqrt(utils::norm_squared(xXi)) + 1.E+3*eps;
+    Jac = utils::norm(xXi) + 1.E+3*eps;
     for (int a = 0; a < eNoN; a++) {
       Nx(0,a) = Nxi(0,a) / Jac;
     }
@@ -515,7 +515,7 @@ void gnn(const int eNoN, const int nsd, const int insd, Array<double>& Nxi, Arra
 
 /// @brief This routine returns a surface normal vector at element "e" and Gauss point
 /// 'g' of face 'lFa' that is the normal weighted by Jac, i.e.
-/// Jac = sqrt(norm_squared(n)), the Jacobian of the mapping from parent surface element to
+/// Jac = norm(n), the Jacobian of the mapping from parent surface element to
 /// reference/old/new configuration.
 ///
 /// cfg denotes which configuration (reference/timestep 0, old/timestep n, or new/timestep n+1). Default reference
@@ -661,7 +661,7 @@ void gnnb(const ComMod& com_mod, const faceType& lFa, const int e, const int g, 
 
     auto v = utils::cross(xXi);
     for (int i = 0; i < nsd; i++) {
-      v(i) = v(i) / sqrt(utils::norm_squared(v));
+      v(i) = v(i) / utils::norm(v);
     }
 
     // Face element surface deflation

--- a/Code/Source/solver/post.cpp
+++ b/Code/Source/solver/post.cpp
@@ -589,7 +589,7 @@ void fib_algn_post(Simulation* simulation, const mshType& lM, Array<double>& res
         for (int i = 0; i < nsd; i++) {
           auto fN_col = fN.col(iFn);
           auto F_fN = mat_fun::mat_mul(F, fN_col);
-          fl.set_col(iFn, F_fN / sqrt(utils::norm_squared(F_fN)));
+          fl.set_col(iFn, F_fN / utils::norm(F_fN));
         }
       }
 
@@ -688,7 +688,7 @@ void fib_dir_post(Simulation* simulation, const mshType& lM, const int nFn, Arra
         for (int i = 0; i < nsd; i++) {
           auto fN_col = fN.col(iFn);
           auto F_fN = mat_fun::mat_mul(F, fN_col);
-          fl.set_col(iFn, F_fN / sqrt(utils::norm_squared(F_fN)));
+          fl.set_col(iFn, F_fN / utils::norm(F_fN));
         }
       }
 
@@ -770,7 +770,7 @@ void fib_stretch(const ComMod& com_mod, const int iEq, const mshType& lM,
 
       // Compute fiber stretch based on 4th invariant: I_{4,f} = F.fN.F.fN
       auto fl = mat_fun::mat_mul(F, lM.fN.rows(0,nsd-1,e));
-      double lambda = sqrt(utils::norm_squared(fl));
+      double lambda = utils::norm(fl);
 
       // L2 projection from integration points to nodes
       double w = lM.w(g)*Jac;
@@ -1369,12 +1369,12 @@ void shl_post(Simulation* simulation, const mshType& lM, const int m, Array<doub
         // Covariant and contravariant bases (ref. config.)
         //
         nn::gnns(nsd, eNoN, Nx, x0, nV0, aCov0, aCnv0);
-        auto Jac0 = sqrt(norm_squared(nV0));
+        auto Jac0 = norm(nV0);
         nV0 = nV0 / Jac0;
 
         // Covariant and contravariant bases (spatial config.)
         nn::gnns(nsd, eNoN, Nx, xc, nV, aCov, aCnv);
-        auto Jac = sqrt(norm_squared(nV));
+        auto Jac = norm(nV);
         nV = nV/Jac;
 
         // Second derivatives for curvature coeffs. (ref. config)
@@ -1445,7 +1445,7 @@ void shl_post(Simulation* simulation, const mshType& lM, const int m, Array<doub
         }
 
         nn::gnns(nsd, lM.eNoN, Nx, tmpX, nV0, aCov0, aCnv0);
-        auto Jac0 = sqrt(norm_squared(nV0));
+        auto Jac0 = norm(nV0);
         nV0  = nV0 / Jac0;
 
         // Covariant and contravariant bases (spatial config.)
@@ -1457,7 +1457,7 @@ void shl_post(Simulation* simulation, const mshType& lM, const int m, Array<doub
         }
 
         nn::gnns(nsd, lM.eNoN, Nx, tmpX, nV, aCov, aCnv);
-        auto Jac = sqrt(norm_squared(nV));
+        auto Jac = norm(nV);
         nV = nV / Jac;
 
         // Compute metric tensor (aa)

--- a/Code/Source/solver/post.cpp
+++ b/Code/Source/solver/post.cpp
@@ -593,7 +593,7 @@ void fib_algn_post(Simulation* simulation, const mshType& lM, Array<double>& res
         }
       }
 
-      double sHat = utils::dot(fl.col(0), fl.col(1));
+      double sHat = fl.rcol(0) * fl.rcol(1);
 
       for (int a = 0; a < eNoN; a++) {
         int Ac = lM.IEN(a,e);

--- a/Code/Source/solver/post.cpp
+++ b/Code/Source/solver/post.cpp
@@ -252,7 +252,7 @@ void bpost(Simulation* simulation, const mshType& lM, Array<double>& res, const 
       double Jac;
 
       for (int a = 0; a < eNoN; a++) {
-        if (utils::is_zero(utils::norm(lnV.col(a)))) {
+        if (utils::is_zero(utils::norm_squared(lnV.col(a)))) {
           lnV.set_col(a, nV);
         }
       }
@@ -589,11 +589,11 @@ void fib_algn_post(Simulation* simulation, const mshType& lM, Array<double>& res
         for (int i = 0; i < nsd; i++) {
           auto fN_col = fN.col(iFn);
           auto F_fN = mat_fun::mat_mul(F, fN_col);
-          fl.set_col(iFn, F_fN / sqrt(utils::norm(F_fN)));
+          fl.set_col(iFn, F_fN / sqrt(utils::norm_squared(F_fN)));
         }
       }
 
-      double sHat = utils::norm(fl.col(0), fl.col(1));
+      double sHat = utils::norm_squared(fl.col(0), fl.col(1));
 
       for (int a = 0; a < eNoN; a++) {
         int Ac = lM.IEN(a,e);
@@ -688,7 +688,7 @@ void fib_dir_post(Simulation* simulation, const mshType& lM, const int nFn, Arra
         for (int i = 0; i < nsd; i++) {
           auto fN_col = fN.col(iFn);
           auto F_fN = mat_fun::mat_mul(F, fN_col);
-          fl.set_col(iFn, F_fN / sqrt(utils::norm(F_fN)));
+          fl.set_col(iFn, F_fN / sqrt(utils::norm_squared(F_fN)));
         }
       }
 
@@ -770,7 +770,7 @@ void fib_stretch(const ComMod& com_mod, const int iEq, const mshType& lM,
 
       // Compute fiber stretch based on 4th invariant: I_{4,f} = F.fN.F.fN
       auto fl = mat_fun::mat_mul(F, lM.fN.rows(0,nsd-1,e));
-      double lambda = sqrt(utils::norm(fl));
+      double lambda = sqrt(utils::norm_squared(fl));
 
       // L2 projection from integration points to nodes
       double w = lM.w(g)*Jac;
@@ -861,7 +861,7 @@ void post(Simulation* simulation, const mshType& lM, Array<double>& res, const S
       double p  = lY(nsd,Ac);
 
       auto u  = lY.col(Ac, {0,nsd-1});
-      double unorm = utils::norm(u);
+      double unorm = utils::norm_squared(u);
       for (int i = 0; i < nsd; i++) {
         res(i,Ac) = (p + 0.5 * rho * unorm) * u(i);
       }
@@ -973,7 +973,7 @@ void post(Simulation* simulation, const mshType& lM, Array<double>& res, const S
             u(i) = u(i) + N(a)*yl(i,a);     
           }
         }
-        double unorm = utils::norm(u);
+        double unorm = utils::norm_squared(u);
 
         for (int i = 0; i < nsd; i++) {
           lRes(i) = (p + 0.5 * rho * unorm) * u(i);
@@ -1369,12 +1369,12 @@ void shl_post(Simulation* simulation, const mshType& lM, const int m, Array<doub
         // Covariant and contravariant bases (ref. config.)
         //
         nn::gnns(nsd, eNoN, Nx, x0, nV0, aCov0, aCnv0);
-        auto Jac0 = sqrt(norm(nV0));
+        auto Jac0 = sqrt(norm_squared(nV0));
         nV0 = nV0 / Jac0;
 
         // Covariant and contravariant bases (spatial config.)
         nn::gnns(nsd, eNoN, Nx, xc, nV, aCov, aCnv);
-        auto Jac = sqrt(norm(nV));
+        auto Jac = sqrt(norm_squared(nV));
         nV = nV/Jac;
 
         // Second derivatives for curvature coeffs. (ref. config)
@@ -1445,7 +1445,7 @@ void shl_post(Simulation* simulation, const mshType& lM, const int m, Array<doub
         }
 
         nn::gnns(nsd, lM.eNoN, Nx, tmpX, nV0, aCov0, aCnv0);
-        auto Jac0 = sqrt(norm(nV0));
+        auto Jac0 = sqrt(norm_squared(nV0));
         nV0  = nV0 / Jac0;
 
         // Covariant and contravariant bases (spatial config.)
@@ -1457,7 +1457,7 @@ void shl_post(Simulation* simulation, const mshType& lM, const int m, Array<doub
         }
 
         nn::gnns(nsd, lM.eNoN, Nx, tmpX, nV, aCov, aCnv);
-        auto Jac = sqrt(norm(nV));
+        auto Jac = sqrt(norm_squared(nV));
         nV = nV / Jac;
 
         // Compute metric tensor (aa)

--- a/Code/Source/solver/post.cpp
+++ b/Code/Source/solver/post.cpp
@@ -593,7 +593,7 @@ void fib_algn_post(Simulation* simulation, const mshType& lM, Array<double>& res
         }
       }
 
-      double sHat = utils::norm_squared(fl.col(0), fl.col(1));
+      double sHat = utils::dot(fl.col(0), fl.col(1));
 
       for (int a = 0; a < eNoN; a++) {
         int Ac = lM.IEN(a,e);

--- a/Code/Source/solver/set_bc.cpp
+++ b/Code/Source/solver/set_bc.cpp
@@ -1626,7 +1626,7 @@ void set_bc_rbnl(ComMod& com_mod, const faceType& lFa, const RobinBoundaryCondit
       h = ks_avg*u + cs_avg*ud;
 
       if (robin_bc.normal_direction_only()) {
-        h = utils::dot(h, nV) * nV;
+        h = (h * nV) * nV;
         for (int a = 0; a < nsd; a++) {
           for (int b = 0; b < nsd; b++) {
             nDn(a,b) = nV(a)*nV(b);

--- a/Code/Source/solver/set_bc.cpp
+++ b/Code/Source/solver/set_bc.cpp
@@ -1321,7 +1321,7 @@ void set_bc_dir_wl(ComMod& com_mod, const bcType& lBc, const mshType& lM, const 
       Vector<double> nV(nsd);
       auto Nx = lFa.Nx.slice(g);
       nn::gnnb(com_mod, lFa, e, g, nsd, nsd-1, eNoNb, Nx, nV, solutions, consts::MechanicalConfigurationType::reference);
-      double Jac = sqrt(utils::norm(nV));
+      double Jac = sqrt(utils::norm_squared(nV));
       nV = nV / Jac;
       double w = lFa.w(g) * Jac;
 
@@ -1587,7 +1587,7 @@ void set_bc_rbnl(ComMod& com_mod, const faceType& lFa, const RobinBoundaryCondit
       Vector<double> nV(nsd);
       auto Nx = lFa.Nx.slice(g);
       nn::gnnb(com_mod, lFa, e, g, nsd, nsd-1, eNoN, Nx, nV, solutions, consts::MechanicalConfigurationType::reference);
-      double Jac = sqrt(utils::norm(nV));
+      double Jac = sqrt(utils::norm_squared(nV));
       nV  = nV / Jac;
       double w = lFa.w(g) * Jac; 
       N = lFa.N.col(g);
@@ -1626,7 +1626,7 @@ void set_bc_rbnl(ComMod& com_mod, const faceType& lFa, const RobinBoundaryCondit
       h = ks_avg*u + cs_avg*ud;
 
       if (robin_bc.normal_direction_only()) {
-        h = utils::norm(h, nV) * nV;
+        h = utils::norm_squared(h, nV) * nV;
         for (int a = 0; a < nsd; a++) {
           for (int b = 0; b < nsd; b++) {
             nDn(a,b) = nV(a)*nV(b);
@@ -1870,7 +1870,7 @@ void set_bc_trac_l(ComMod& com_mod, const CmMod& cm_mod, const bcType& lBc, cons
       Vector<double> nV(nsd);
       auto Nx = lFa.Nx.slice(g);
       nn::gnnb(com_mod, lFa, e, g, nsd, nsd-1, eNoN, Nx, nV, solutions, consts::MechanicalConfigurationType::reference);
-      double Jac = sqrt(utils::norm(nV));
+      double Jac = sqrt(utils::norm_squared(nV));
       double w = lFa.w(g)*Jac;
       N = lFa.N.col(g);
 

--- a/Code/Source/solver/set_bc.cpp
+++ b/Code/Source/solver/set_bc.cpp
@@ -1321,7 +1321,7 @@ void set_bc_dir_wl(ComMod& com_mod, const bcType& lBc, const mshType& lM, const 
       Vector<double> nV(nsd);
       auto Nx = lFa.Nx.slice(g);
       nn::gnnb(com_mod, lFa, e, g, nsd, nsd-1, eNoNb, Nx, nV, solutions, consts::MechanicalConfigurationType::reference);
-      double Jac = sqrt(utils::norm_squared(nV));
+      double Jac = utils::norm(nV);
       nV = nV / Jac;
       double w = lFa.w(g) * Jac;
 
@@ -1587,7 +1587,7 @@ void set_bc_rbnl(ComMod& com_mod, const faceType& lFa, const RobinBoundaryCondit
       Vector<double> nV(nsd);
       auto Nx = lFa.Nx.slice(g);
       nn::gnnb(com_mod, lFa, e, g, nsd, nsd-1, eNoN, Nx, nV, solutions, consts::MechanicalConfigurationType::reference);
-      double Jac = sqrt(utils::norm_squared(nV));
+      double Jac = utils::norm(nV);
       nV  = nV / Jac;
       double w = lFa.w(g) * Jac; 
       N = lFa.N.col(g);
@@ -1870,7 +1870,7 @@ void set_bc_trac_l(ComMod& com_mod, const CmMod& cm_mod, const bcType& lBc, cons
       Vector<double> nV(nsd);
       auto Nx = lFa.Nx.slice(g);
       nn::gnnb(com_mod, lFa, e, g, nsd, nsd-1, eNoN, Nx, nV, solutions, consts::MechanicalConfigurationType::reference);
-      double Jac = sqrt(utils::norm_squared(nV));
+      double Jac = utils::norm(nV);
       double w = lFa.w(g)*Jac;
       N = lFa.N.col(g);
 

--- a/Code/Source/solver/set_bc.cpp
+++ b/Code/Source/solver/set_bc.cpp
@@ -1626,7 +1626,7 @@ void set_bc_rbnl(ComMod& com_mod, const faceType& lFa, const RobinBoundaryCondit
       h = ks_avg*u + cs_avg*ud;
 
       if (robin_bc.normal_direction_only()) {
-        h = utils::norm_squared(h, nV) * nV;
+        h = utils::dot(h, nV) * nV;
         for (int a = 0; a < nsd; a++) {
           for (int b = 0; b < nsd; b++) {
             nDn(a,b) = nV(a)*nV(b);

--- a/Code/Source/solver/shells.cpp
+++ b/Code/Source/solver/shells.cpp
@@ -248,7 +248,7 @@ void shell_3d(ComMod& com_mod, const mshType& lM, const int g, const int eNoN,
   Array<double> aCov0(3,2), aCnv0(3,2);
   Vector<double> nV0(3);
   nn::gnns(nsd, lM.eNoN, Nx, x0, nV0, aCov0, aCnv0);
-  double Jac0 = sqrt(utils::norm_squared(nV0));
+  double Jac0 = utils::norm(nV0);
   nV0 = nV0 / Jac0;
 
   // Second derivatives for computing curvature coeffs. (ref. config)
@@ -300,7 +300,7 @@ void shell_3d(ComMod& com_mod, const mshType& lM, const int g, const int eNoN,
   Array<double> aCov(3,2), aCnv(3,2);
   Vector<double> nV(3);
   nn::gnns(nsd, eNoN, Nx, xc, nV, aCov, aCnv);
-  double Jac = sqrt(utils::norm_squared(nV));
+  double Jac = utils::norm(nV);
   nV = nV / Jac;
 
   // Second derivatives for computing curvature coeffs. (cur. config)
@@ -609,7 +609,7 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
   Array<double> aCov0(3,2), aCnv0(3,2);
   Vector<double> nV0(3);
   nn::gnns(nsd, lM.eNoN, lM.Nx.rslice(0), tmpA, nV0, aCov0, aCnv0);
-  double Jac0 = sqrt(utils::norm_squared(nV0));
+  double Jac0 = utils::norm(nV0);
   nV0 = nV0 / Jac0;
 
   // Covariant and contravariant bases in current config
@@ -623,7 +623,7 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
   Array<double> aCov(3,2), aCnv(3,2);
   Vector<double> nV(3);
   nn::gnns(nsd, lM.eNoN, lM.Nx.rslice(0), tmpA, nV, aCov, aCnv);
-  double Jac = sqrt(norm_squared(nV));
+  double Jac = norm(nV);
   nV = nV / Jac;
 
   // Update the position vector of the `artificial' or `ghost' nodes
@@ -644,7 +644,7 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
       // Reference config
       // eI = eI0 = aI0/|aI0| (reference config)
       //
-      auto aIi = 1.0 / sqrt(norm_squared(a0.col(i)));
+      auto aIi = 1.0 / norm(a0.col(i));
       auto eI = a0.col(i) * aIi;
 
       // nI = nI0 = eI0 x n0 (reference config)
@@ -664,7 +664,7 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
       // Current config
       // eI = aI/|aI| (current config)
       //
-      aIi = 1.0 / sqrt(utils::norm_squared(a.col(i)));
+      aIi = 1.0 / utils::norm(a.col(i));
       eI = a.col(i)*aIi;
 
       // nI = eI x n (currnt config)
@@ -978,7 +978,7 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
 
       if (utils::btest(lM.sbc(i,e),enum_int(BoundaryConditionType::bType_fix))) {
         // eI = eI0 = aI0/|aI0| (reference config)
-        aIi = 1.0 / sqrt(norm_squared(a0.col(i)));
+        aIi = 1.0 / norm(a0.col(i));
         eI = a0.col(i) * aIi;
 
         // nI = nI0 = eI0 x n0 (reference config)
@@ -989,7 +989,7 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
 
       } else { 
         // eI = aI/|aI| (current config)
-        aIi = 1.0 / sqrt(norm_squared(a.col(i)));
+        aIi = 1.0 / norm(a.col(i));
         eI = a.col(i)*aIi;
 
         // nI = eI x n (currnt config)
@@ -1259,7 +1259,7 @@ void shell_cst(ComMod& com_mod, const mshType& lM, const int e, const int eNoN, 
   nn::gnns(nsd, lM.eNoN, Nx, tmpX, nV0, aCov0, aCnv0);
   //CALL GNNS(lM%eNoN, Nx, tmpX, nV0, aCov0, aCnv0)
 
-  double Jac0 = sqrt(utils::norm_squared(nV0));
+  double Jac0 = utils::norm(nV0);
   nV0 = nV0 / Jac0;
 
   // Covariant and contravariant bases in current config
@@ -1275,7 +1275,7 @@ void shell_cst(ComMod& com_mod, const mshType& lM, const int e, const int eNoN, 
 
   nn::gnns(nsd, lM.eNoN, Nx, tmpX, nV, aCov, aCnv);
 
-  double Jac = sqrt(utils::norm_squared(nV));
+  double Jac = utils::norm(nV);
   nV = nV / Jac;
 
   // Compute metric tensor in reference and current config

--- a/Code/Source/solver/shells.cpp
+++ b/Code/Source/solver/shells.cpp
@@ -707,32 +707,32 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
   // a.gCnv (reference config)
   //
   Array<double> adg0(3,3);
-  adg0(0,0) = dot(a0.col(3), aCnv0.col(0));    // xi_4
-  adg0(0,1) = dot(a0.col(4), aCnv0.col(0));    // xi_5
-  adg0(0,2) = dot(a0.col(5), aCnv0.col(0));    // xi_6
+  adg0(0, 0) = a0.rcol(3) * aCnv0.rcol(0); // xi_4
+  adg0(0, 1) = a0.rcol(4) * aCnv0.rcol(0); // xi_5
+  adg0(0, 2) = a0.rcol(5) * aCnv0.rcol(0); // xi_6
 
-  adg0(1,0) = dot(a0.col(3), aCnv0.col(1));    // eta_4
-  adg0(1,1) = dot(a0.col(4), aCnv0.col(1));    // eta_5
-  adg0(1,2) = dot(a0.col(5), aCnv0.col(1));    // eta_6
+  adg0(1, 0) = a0.rcol(3) * aCnv0.rcol(1); // eta_4
+  adg0(1, 1) = a0.rcol(4) * aCnv0.rcol(1); // eta_5
+  adg0(1, 2) = a0.rcol(5) * aCnv0.rcol(1); // eta_6
 
-  adg0(2,0) = dot(a0.col(3), nV0);        // z_4
-  adg0(2,1) = dot(a0.col(4), nV0);        // z_5
-  adg0(2,2) = dot(a0.col(5), nV0);        // z_6
+  adg0(2, 0) = a0.rcol(3) * nV0; // z_4
+  adg0(2, 1) = a0.rcol(4) * nV0; // z_5
+  adg0(2, 2) = a0.rcol(5) * nV0; // z_6
 
   // a.gCnv (current config)
   //
   Array<double> adg(3,3);
-  adg(0,0) = dot(a.col(3), aCnv.col(0));   // xi_4
-  adg(0,1) = dot(a.col(4), aCnv.col(0));   // xi_5
-  adg(0,2) = dot(a.col(5), aCnv.col(0));   // xi_6
+  adg(0, 0) = a.rcol(3) * aCnv.rcol(0); // xi_4
+  adg(0, 1) = a.rcol(4) * aCnv.rcol(0); // xi_5
+  adg(0, 2) = a.rcol(5) * aCnv.rcol(0); // xi_6
 
-  adg(1,0) = dot(a.col(3), aCnv.col(1));   // eta_4
-  adg(1,1) = dot(a.col(4), aCnv.col(1));   // eta_5
-  adg(1,2) = dot(a.col(5), aCnv.col(1));   // eta_6
+  adg(1, 0) = a.rcol(3) * aCnv.rcol(1); // eta_4
+  adg(1, 1) = a.rcol(4) * aCnv.rcol(1); // eta_5
+  adg(1, 2) = a.rcol(5) * aCnv.rcol(1); // eta_6
 
-  adg(2,0) = dot(a.col(3), nV);        // z_4
-  adg(2,1) = dot(a.col(4), nV);        // z_5
-  adg(2,2) = dot(a.col(5), nV);        // z_6
+  adg(2, 0) = a.rcol(3) * nV; // z_4
+  adg(2, 1) = a.rcol(4) * nV; // z_5
+  adg(2, 2) = a.rcol(5) * nV; // z_6
 
   // Xi matrix (reference config)
   //
@@ -1000,7 +1000,7 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
         nI(1) = eI(2)*nV(0) - eI(0)*nV(2);
         nI(2) = eI(0)*nV(1) - eI(1)*nV(0);
 
-        cI = dot(a.col(i),a.col(p))*aIi*aIi;
+        cI = (a.rcol(i) * a.rcol(p)) * aIi * aIi;
         nInI = mat_dyad_prod(nI, nI, 3);
         eIeI = mat_dyad_prod(eI, eI, 3);
         eIaP = mat_dyad_prod(eI, a.col(p), 3);

--- a/Code/Source/solver/shells.cpp
+++ b/Code/Source/solver/shells.cpp
@@ -707,32 +707,32 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
   // a.gCnv (reference config)
   //
   Array<double> adg0(3,3);
-  adg0(0,0) = norm_squared(a0.col(3), aCnv0.col(0));    // xi_4
-  adg0(0,1) = norm_squared(a0.col(4), aCnv0.col(0));    // xi_5
-  adg0(0,2) = norm_squared(a0.col(5), aCnv0.col(0));    // xi_6
+  adg0(0,0) = dot(a0.col(3), aCnv0.col(0));    // xi_4
+  adg0(0,1) = dot(a0.col(4), aCnv0.col(0));    // xi_5
+  adg0(0,2) = dot(a0.col(5), aCnv0.col(0));    // xi_6
 
-  adg0(1,0) = norm_squared(a0.col(3), aCnv0.col(1));    // eta_4
-  adg0(1,1) = norm_squared(a0.col(4), aCnv0.col(1));    // eta_5
-  adg0(1,2) = norm_squared(a0.col(5), aCnv0.col(1));    // eta_6
+  adg0(1,0) = dot(a0.col(3), aCnv0.col(1));    // eta_4
+  adg0(1,1) = dot(a0.col(4), aCnv0.col(1));    // eta_5
+  adg0(1,2) = dot(a0.col(5), aCnv0.col(1));    // eta_6
 
-  adg0(2,0) = norm_squared(a0.col(3), nV0);        // z_4
-  adg0(2,1) = norm_squared(a0.col(4), nV0);        // z_5
-  adg0(2,2) = norm_squared(a0.col(5), nV0);        // z_6
+  adg0(2,0) = dot(a0.col(3), nV0);        // z_4
+  adg0(2,1) = dot(a0.col(4), nV0);        // z_5
+  adg0(2,2) = dot(a0.col(5), nV0);        // z_6
 
   // a.gCnv (current config)
   //
   Array<double> adg(3,3);
-  adg(0,0) = norm_squared(a.col(3), aCnv.col(0));   // xi_4
-  adg(0,1) = norm_squared(a.col(4), aCnv.col(0));   // xi_5
-  adg(0,2) = norm_squared(a.col(5), aCnv.col(0));   // xi_6
+  adg(0,0) = dot(a.col(3), aCnv.col(0));   // xi_4
+  adg(0,1) = dot(a.col(4), aCnv.col(0));   // xi_5
+  adg(0,2) = dot(a.col(5), aCnv.col(0));   // xi_6
 
-  adg(1,0) = norm_squared(a.col(3), aCnv.col(1));   // eta_4
-  adg(1,1) = norm_squared(a.col(4), aCnv.col(1));   // eta_5
-  adg(1,2) = norm_squared(a.col(5), aCnv.col(1));   // eta_6
+  adg(1,0) = dot(a.col(3), aCnv.col(1));   // eta_4
+  adg(1,1) = dot(a.col(4), aCnv.col(1));   // eta_5
+  adg(1,2) = dot(a.col(5), aCnv.col(1));   // eta_6
 
-  adg(2,0) = norm_squared(a.col(3), nV);        // z_4
-  adg(2,1) = norm_squared(a.col(4), nV);        // z_5
-  adg(2,2) = norm_squared(a.col(5), nV);        // z_6
+  adg(2,0) = dot(a.col(3), nV);        // z_4
+  adg(2,1) = dot(a.col(4), nV);        // z_5
+  adg(2,2) = dot(a.col(5), nV);        // z_6
 
   // Xi matrix (reference config)
   //
@@ -1000,7 +1000,7 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
         nI(1) = eI(2)*nV(0) - eI(0)*nV(2);
         nI(2) = eI(0)*nV(1) - eI(1)*nV(0);
 
-        cI = norm_squared(a.col(i),a.col(p))*aIi*aIi;
+        cI = dot(a.col(i),a.col(p))*aIi*aIi;
         nInI = mat_dyad_prod(nI, nI, 3);
         eIeI = mat_dyad_prod(eI, eI, 3);
         eIaP = mat_dyad_prod(eI, a.col(p), 3);

--- a/Code/Source/solver/shells.cpp
+++ b/Code/Source/solver/shells.cpp
@@ -248,7 +248,7 @@ void shell_3d(ComMod& com_mod, const mshType& lM, const int g, const int eNoN,
   Array<double> aCov0(3,2), aCnv0(3,2);
   Vector<double> nV0(3);
   nn::gnns(nsd, lM.eNoN, Nx, x0, nV0, aCov0, aCnv0);
-  double Jac0 = sqrt(utils::norm(nV0));
+  double Jac0 = sqrt(utils::norm_squared(nV0));
   nV0 = nV0 / Jac0;
 
   // Second derivatives for computing curvature coeffs. (ref. config)
@@ -300,7 +300,7 @@ void shell_3d(ComMod& com_mod, const mshType& lM, const int g, const int eNoN,
   Array<double> aCov(3,2), aCnv(3,2);
   Vector<double> nV(3);
   nn::gnns(nsd, eNoN, Nx, xc, nV, aCov, aCnv);
-  double Jac = sqrt(utils::norm(nV));
+  double Jac = sqrt(utils::norm_squared(nV));
   nV = nV / Jac;
 
   // Second derivatives for computing curvature coeffs. (cur. config)
@@ -609,7 +609,7 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
   Array<double> aCov0(3,2), aCnv0(3,2);
   Vector<double> nV0(3);
   nn::gnns(nsd, lM.eNoN, lM.Nx.rslice(0), tmpA, nV0, aCov0, aCnv0);
-  double Jac0 = sqrt(utils::norm(nV0));
+  double Jac0 = sqrt(utils::norm_squared(nV0));
   nV0 = nV0 / Jac0;
 
   // Covariant and contravariant bases in current config
@@ -623,7 +623,7 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
   Array<double> aCov(3,2), aCnv(3,2);
   Vector<double> nV(3);
   nn::gnns(nsd, lM.eNoN, lM.Nx.rslice(0), tmpA, nV, aCov, aCnv);
-  double Jac = sqrt(norm(nV));
+  double Jac = sqrt(norm_squared(nV));
   nV = nV / Jac;
 
   // Update the position vector of the `artificial' or `ghost' nodes
@@ -644,7 +644,7 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
       // Reference config
       // eI = eI0 = aI0/|aI0| (reference config)
       //
-      auto aIi = 1.0 / sqrt(norm(a0.col(i)));
+      auto aIi = 1.0 / sqrt(norm_squared(a0.col(i)));
       auto eI = a0.col(i) * aIi;
 
       // nI = nI0 = eI0 x n0 (reference config)
@@ -664,7 +664,7 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
       // Current config
       // eI = aI/|aI| (current config)
       //
-      aIi = 1.0 / sqrt(utils::norm(a.col(i)));
+      aIi = 1.0 / sqrt(utils::norm_squared(a.col(i)));
       eI = a.col(i)*aIi;
 
       // nI = eI x n (currnt config)
@@ -707,32 +707,32 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
   // a.gCnv (reference config)
   //
   Array<double> adg0(3,3);
-  adg0(0,0) = norm(a0.col(3), aCnv0.col(0));    // xi_4
-  adg0(0,1) = norm(a0.col(4), aCnv0.col(0));    // xi_5
-  adg0(0,2) = norm(a0.col(5), aCnv0.col(0));    // xi_6
+  adg0(0,0) = norm_squared(a0.col(3), aCnv0.col(0));    // xi_4
+  adg0(0,1) = norm_squared(a0.col(4), aCnv0.col(0));    // xi_5
+  adg0(0,2) = norm_squared(a0.col(5), aCnv0.col(0));    // xi_6
 
-  adg0(1,0) = norm(a0.col(3), aCnv0.col(1));    // eta_4
-  adg0(1,1) = norm(a0.col(4), aCnv0.col(1));    // eta_5
-  adg0(1,2) = norm(a0.col(5), aCnv0.col(1));    // eta_6
+  adg0(1,0) = norm_squared(a0.col(3), aCnv0.col(1));    // eta_4
+  adg0(1,1) = norm_squared(a0.col(4), aCnv0.col(1));    // eta_5
+  adg0(1,2) = norm_squared(a0.col(5), aCnv0.col(1));    // eta_6
 
-  adg0(2,0) = norm(a0.col(3), nV0);        // z_4
-  adg0(2,1) = norm(a0.col(4), nV0);        // z_5
-  adg0(2,2) = norm(a0.col(5), nV0);        // z_6
+  adg0(2,0) = norm_squared(a0.col(3), nV0);        // z_4
+  adg0(2,1) = norm_squared(a0.col(4), nV0);        // z_5
+  adg0(2,2) = norm_squared(a0.col(5), nV0);        // z_6
 
   // a.gCnv (current config)
   //
   Array<double> adg(3,3);
-  adg(0,0) = norm(a.col(3), aCnv.col(0));   // xi_4
-  adg(0,1) = norm(a.col(4), aCnv.col(0));   // xi_5
-  adg(0,2) = norm(a.col(5), aCnv.col(0));   // xi_6
+  adg(0,0) = norm_squared(a.col(3), aCnv.col(0));   // xi_4
+  adg(0,1) = norm_squared(a.col(4), aCnv.col(0));   // xi_5
+  adg(0,2) = norm_squared(a.col(5), aCnv.col(0));   // xi_6
 
-  adg(1,0) = norm(a.col(3), aCnv.col(1));   // eta_4
-  adg(1,1) = norm(a.col(4), aCnv.col(1));   // eta_5
-  adg(1,2) = norm(a.col(5), aCnv.col(1));   // eta_6
+  adg(1,0) = norm_squared(a.col(3), aCnv.col(1));   // eta_4
+  adg(1,1) = norm_squared(a.col(4), aCnv.col(1));   // eta_5
+  adg(1,2) = norm_squared(a.col(5), aCnv.col(1));   // eta_6
 
-  adg(2,0) = norm(a.col(3), nV);        // z_4
-  adg(2,1) = norm(a.col(4), nV);        // z_5
-  adg(2,2) = norm(a.col(5), nV);        // z_6
+  adg(2,0) = norm_squared(a.col(3), nV);        // z_4
+  adg(2,1) = norm_squared(a.col(4), nV);        // z_5
+  adg(2,2) = norm_squared(a.col(5), nV);        // z_6
 
   // Xi matrix (reference config)
   //
@@ -978,7 +978,7 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
 
       if (utils::btest(lM.sbc(i,e),enum_int(BoundaryConditionType::bType_fix))) {
         // eI = eI0 = aI0/|aI0| (reference config)
-        aIi = 1.0 / sqrt(norm(a0.col(i)));
+        aIi = 1.0 / sqrt(norm_squared(a0.col(i)));
         eI = a0.col(i) * aIi;
 
         // nI = nI0 = eI0 x n0 (reference config)
@@ -989,7 +989,7 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
 
       } else { 
         // eI = aI/|aI| (current config)
-        aIi = 1.0 / sqrt(norm(a.col(i)));
+        aIi = 1.0 / sqrt(norm_squared(a.col(i)));
         eI = a.col(i)*aIi;
 
         // nI = eI x n (currnt config)
@@ -1000,7 +1000,7 @@ void shell_bend_cst(ComMod& com_mod, const mshType& lM, const int e, const Vecto
         nI(1) = eI(2)*nV(0) - eI(0)*nV(2);
         nI(2) = eI(0)*nV(1) - eI(1)*nV(0);
 
-        cI = norm(a.col(i),a.col(p))*aIi*aIi;
+        cI = norm_squared(a.col(i),a.col(p))*aIi*aIi;
         nInI = mat_dyad_prod(nI, nI, 3);
         eIeI = mat_dyad_prod(eI, eI, 3);
         eIaP = mat_dyad_prod(eI, a.col(p), 3);
@@ -1259,7 +1259,7 @@ void shell_cst(ComMod& com_mod, const mshType& lM, const int e, const int eNoN, 
   nn::gnns(nsd, lM.eNoN, Nx, tmpX, nV0, aCov0, aCnv0);
   //CALL GNNS(lM%eNoN, Nx, tmpX, nV0, aCov0, aCnv0)
 
-  double Jac0 = sqrt(utils::norm(nV0));
+  double Jac0 = sqrt(utils::norm_squared(nV0));
   nV0 = nV0 / Jac0;
 
   // Covariant and contravariant bases in current config
@@ -1275,7 +1275,7 @@ void shell_cst(ComMod& com_mod, const mshType& lM, const int e, const int eNoN, 
 
   nn::gnns(nsd, lM.eNoN, Nx, tmpX, nV, aCov, aCnv);
 
-  double Jac = sqrt(utils::norm(nV));
+  double Jac = sqrt(utils::norm_squared(nV));
   nV = nV / Jac;
 
   // Compute metric tensor in reference and current config

--- a/Code/Source/solver/txt.cpp
+++ b/Code/Source/solver/txt.cpp
@@ -274,7 +274,7 @@ void txt(Simulation* simulation, const bool init_write, const SolutionStates& so
           post::all_post(simulation, tmpV, solutions, oGrp, iEq);
           for (int a = 0; a < tnNo; a++) {
             auto vec = tmpV.col(a, {0,nsd-1});
-            tmpV(0,a) = sqrt(norm_squared(vec));
+            tmpV(0,a) = norm(vec);
           }
           l = 1;
         break;

--- a/Code/Source/solver/txt.cpp
+++ b/Code/Source/solver/txt.cpp
@@ -274,7 +274,7 @@ void txt(Simulation* simulation, const bool init_write, const SolutionStates& so
           post::all_post(simulation, tmpV, solutions, oGrp, iEq);
           for (int a = 0; a < tnNo; a++) {
             auto vec = tmpV.col(a, {0,nsd-1});
-            tmpV(0,a) = sqrt(norm(vec));
+            tmpV(0,a) = sqrt(norm_squared(vec));
           }
           l = 1;
         break;

--- a/Code/Source/solver/uris.cpp
+++ b/Code/Source/solver/uris.cpp
@@ -1051,7 +1051,7 @@ void uris_calc_sdf(ComMod& com_mod) {
       Vector<double> unitNormal(nsd);
       uris_find_closest_face_centroid(uris_obj, xp, nsd, minS, Ec, jM, xb);
       uris_face_unit_normal(uris_obj, nsd, jM, Ec, unitNormal);
-      const double dotp = utils::norm(xp - xb, unitNormal);
+      const double dotp = utils::norm_squared(xp - xb, unitNormal);
       double sdf_sign = uris_compute_sdf_sign(uris_obj, xp, xb, dotp);
 
       uris_obj.sdf[ca] = sdf_sign * minS;
@@ -1175,8 +1175,8 @@ bool same_side(const Vector<double>& v1, const Vector<double>& v2,
   V.set_col(1, v31);
 
   const Vector<double> N = utils::cross(V);
-  const double dotV4 = utils::norm(N, v4-v1);
-  const double dotP = utils::norm(N, p-v1);
+  const double dotV4 = utils::norm_squared(N, v4-v1);
+  const double dotP = utils::norm_squared(N, p-v1);
 
   // P and v4 are on the same side if their dot products share a sign
   const bool sameside = (dotP >= 0.0) == (dotV4 >= 0.0);
@@ -1258,7 +1258,7 @@ void uris_face_unit_normal(const urisType& uris_obj, const int nsd, const int jM
   }
 
   unitNormal = utils::cross(xXi);
-  const auto Jac = sqrt(utils::norm(unitNormal));
+  const auto Jac = sqrt(utils::norm_squared(unitNormal));
   if (uris_obj.invert_normal) {
     unitNormal = -unitNormal / Jac;
   } else {
@@ -1280,7 +1280,7 @@ double uris_compute_sdf_sign(const urisType& uris_obj, const Vector<double>& xp,
   // sensitive to local face normal orientation inconsistency and more 
   // aligned with the intended physical flow direction
   if (uris_obj.clsFlg) {
-    auto dot_nrm = utils::norm(xp-xb, uris_obj.nrm);
+    auto dot_nrm = utils::norm_squared(xp-xb, uris_obj.nrm);
     return (dot_nrm < 0.0 && dotP < 0.0) ? -1.0 : 1.0;
   }
   return (dotP < 0.0) ? -1.0 : 1.0;

--- a/Code/Source/solver/uris.cpp
+++ b/Code/Source/solver/uris.cpp
@@ -1051,7 +1051,7 @@ void uris_calc_sdf(ComMod& com_mod) {
       Vector<double> unitNormal(nsd);
       uris_find_closest_face_centroid(uris_obj, xp, nsd, minS, Ec, jM, xb);
       uris_face_unit_normal(uris_obj, nsd, jM, Ec, unitNormal);
-      const double dotp = utils::norm_squared(xp - xb, unitNormal);
+      const double dotp = utils::dot(xp - xb, unitNormal);
       double sdf_sign = uris_compute_sdf_sign(uris_obj, xp, xb, dotp);
 
       uris_obj.sdf[ca] = sdf_sign * minS;
@@ -1175,8 +1175,8 @@ bool same_side(const Vector<double>& v1, const Vector<double>& v2,
   V.set_col(1, v31);
 
   const Vector<double> N = utils::cross(V);
-  const double dotV4 = utils::norm_squared(N, v4-v1);
-  const double dotP = utils::norm_squared(N, p-v1);
+  const double dotV4 = utils::dot(N, v4-v1);
+  const double dotP = utils::dot(N, p-v1);
 
   // P and v4 are on the same side if their dot products share a sign
   const bool sameside = (dotP >= 0.0) == (dotV4 >= 0.0);
@@ -1280,7 +1280,7 @@ double uris_compute_sdf_sign(const urisType& uris_obj, const Vector<double>& xp,
   // sensitive to local face normal orientation inconsistency and more 
   // aligned with the intended physical flow direction
   if (uris_obj.clsFlg) {
-    auto dot_nrm = utils::norm_squared(xp-xb, uris_obj.nrm);
+    auto dot_nrm = utils::dot(xp-xb, uris_obj.nrm);
     return (dot_nrm < 0.0 && dotP < 0.0) ? -1.0 : 1.0;
   }
   return (dotP < 0.0) ? -1.0 : 1.0;

--- a/Code/Source/solver/uris.cpp
+++ b/Code/Source/solver/uris.cpp
@@ -1258,7 +1258,7 @@ void uris_face_unit_normal(const urisType& uris_obj, const int nsd, const int jM
   }
 
   unitNormal = utils::cross(xXi);
-  const auto Jac = sqrt(utils::norm_squared(unitNormal));
+  const auto Jac = utils::norm(unitNormal);
   if (uris_obj.invert_normal) {
     unitNormal = -unitNormal / Jac;
   } else {

--- a/Code/Source/solver/uris.cpp
+++ b/Code/Source/solver/uris.cpp
@@ -1046,7 +1046,7 @@ void uris_calc_sdf(ComMod& com_mod) {
       Vector<double> unitNormal(nsd);
       uris_find_closest_face_centroid(uris_obj, xp, nsd, minS, Ec, jM, xb);
       uris_face_unit_normal(uris_obj, nsd, jM, Ec, unitNormal);
-      const double dotp = utils::dot(xp - xb, unitNormal);
+      const double dotp = (xp - xb) * unitNormal;
       double sdf_sign = uris_compute_sdf_sign(uris_obj, xp, xb, dotp);
 
       uris_obj.sdf[ca] = sdf_sign * minS;
@@ -1170,8 +1170,8 @@ bool same_side(const Vector<double>& v1, const Vector<double>& v2,
   V.set_col(1, v31);
 
   const Vector<double> N = utils::cross(V);
-  const double dotV4 = utils::dot(N, v4-v1);
-  const double dotP = utils::dot(N, p-v1);
+  const double dotV4 = N * (v4 - v1);
+  const double dotP = N * (p - v1);
 
   // P and v4 are on the same side if their dot products share a sign
   const bool sameside = (dotP >= 0.0) == (dotV4 >= 0.0);
@@ -1275,7 +1275,7 @@ double uris_compute_sdf_sign(const urisType& uris_obj, const Vector<double>& xp,
   // sensitive to local face normal orientation inconsistency and more 
   // aligned with the intended physical flow direction
   if (uris_obj.clsFlg) {
-    auto dot_nrm = utils::dot(xp-xb, uris_obj.nrm);
+    auto dot_nrm = (xp - xb) * uris_obj.nrm;
     return (dot_nrm < 0.0 && dotP < 0.0) ? -1.0 : 1.0;
   }
   return (dotP < 0.0) ? -1.0 : 1.0;

--- a/Code/Source/solver/utils.cpp
+++ b/Code/Source/solver/utils.cpp
@@ -217,15 +217,6 @@ double norm_squared(const Vector<double>& U)
   return norm_squared;
 }
 
-double dot(const Vector<double>& U, const Vector<double>& V)
-{
-  double dot = 0.0;
-  for (int i = 0; i < U.size(); i++) {
-    dot += U(i)*V(i);
-  }
-  return dot;
-}
-
 double norm_squared(const Array<double>& U)
 {
   int m = U.nrows();
@@ -267,6 +258,15 @@ double norm_squared(const Array<double>& U)
     }
 
   return norm_squared;
+}
+
+double dot(const Vector<double>& U, const Vector<double>& V)
+{
+  double dot = 0.0;
+  for (int i = 0; i < U.size(); i++) {
+    dot += U(i)*V(i);
+  }
+  return dot;
 }
 
 void print_mem(const std::string& type, const std::string& prefix, const double memory_in_use, const double memory_returned)

--- a/Code/Source/solver/utils.cpp
+++ b/Code/Source/solver/utils.cpp
@@ -217,13 +217,13 @@ double norm_squared(const Vector<double>& U)
   return norm_squared;
 }
 
-double norm_squared(const Vector<double>& U, const Vector<double>& V)
+double dot(const Vector<double>& U, const Vector<double>& V)
 {
-  double norm_squared = 0.0;
+  double dot = 0.0;
   for (int i = 0; i < U.size(); i++) {
-    norm_squared += U(i)*V(i);
+    dot += U(i)*V(i);
   }
-  return norm_squared;
+  return dot;
 }
 
 double norm_squared(const Array<double>& U)

--- a/Code/Source/solver/utils.cpp
+++ b/Code/Source/solver/utils.cpp
@@ -260,6 +260,16 @@ double norm_squared(const Array<double>& U)
   return norm_squared;
 }
 
+double norm(const Vector<double> &U)
+{
+  return std::sqrt(norm_squared(U));
+}
+
+double norm(const Array<double> &U)
+{
+  return std::sqrt(norm_squared(U));
+}
+
 double dot(const Vector<double>& U, const Vector<double>& V)
 {
   double dot = 0.0;

--- a/Code/Source/solver/utils.cpp
+++ b/Code/Source/solver/utils.cpp
@@ -14,6 +14,8 @@
 #include <fstream>
 #include <sys/resource.h>
 
+#include "FE/Common/FEException.h"
+
 /* MacOS
 #include <mach/task.h>
 #include <mach/mach_init.h>
@@ -272,6 +274,10 @@ double norm(const Array<double> &U)
 
 double dot(const Vector<double>& U, const Vector<double>& V)
 {
+  if (U.size() != V.size()) {
+    svmp::raise<svmp::FE::InvalidArgumentException>(SVMP_HERE, "Vectors must have the same size for dot product.");
+  }
+
   double dot = 0.0;
   for (int i = 0; i < U.size(); i++) {
     dot += U(i)*V(i);

--- a/Code/Source/solver/utils.cpp
+++ b/Code/Source/solver/utils.cpp
@@ -272,19 +272,6 @@ double norm(const Array<double> &U)
   return std::sqrt(norm_squared(U));
 }
 
-double dot(const Vector<double>& U, const Vector<double>& V)
-{
-  if (U.size() != V.size()) {
-    svmp::raise<svmp::FE::InvalidArgumentException>(SVMP_HERE, "Vectors must have the same size for dot product.");
-  }
-
-  double dot = 0.0;
-  for (int i = 0; i < U.size(); i++) {
-    dot += U(i)*V(i);
-  }
-  return dot;
-}
-
 void print_mem(const std::string& type, const std::string& prefix, const double memory_in_use, const double memory_returned)
 {
   double s = (1024.0);

--- a/Code/Source/solver/utils.cpp
+++ b/Code/Source/solver/utils.cpp
@@ -246,7 +246,7 @@ double norm_squared(const Array<double>& U)
 
     case 4:
       for (int i = 0; i < n; i++) {
-        norm_squared = norm_squared + U(0,i)*U(0,i) + U(1,i)*U(1,i) + U(2,i)*U(2,i); + U(3,i)*U(3,i);
+        norm_squared = norm_squared + U(0,i)*U(0,i) + U(1,i)*U(1,i) + U(2,i)*U(2,i) + U(3,i)*U(3,i);
       }
     break;
 

--- a/Code/Source/solver/utils.cpp
+++ b/Code/Source/solver/utils.cpp
@@ -204,69 +204,69 @@ double mem_usage(const bool print_usage, const std::string& prefix)
   return resident_set;
 }
 
-/// @brief This function will compute second NORM of a vector.
+/// @brief This function will compute the squared Euclidean norm of a vector.
 ///
 /// Replicates 'PURE FUNCTION NORMS(U, V)' defined in UTIL.f.
 //
-double norm(const Vector<double>& U)
+double norm_squared(const Vector<double>& U)
 {
-  double norm = 0.0;
+  double norm_squared = 0.0;
   for (int i = 0; i < U.size(); i++) {
-    norm += U(i)*U(i);
+    norm_squared += U(i)*U(i);
   }
-  return norm;
+  return norm_squared;
 }
 
-double norm(const Vector<double>& U, const Vector<double>& V)
+double norm_squared(const Vector<double>& U, const Vector<double>& V)
 {
-  double norm = 0.0;
+  double norm_squared = 0.0;
   for (int i = 0; i < U.size(); i++) {
-    norm += U(i)*V(i);
+    norm_squared += U(i)*V(i);
   }
-  return norm;
+  return norm_squared;
 }
 
-double norm(const Array<double>& U)
+double norm_squared(const Array<double>& U)
 {
   int m = U.nrows();
   int n = U.ncols();
-  double norm = 0.0;
+  double norm_squared = 0.0;
 
   switch (m) { 
     case 1:
       for (int i = 0; i < n; i++) {
-        norm = norm + U(0,i)*U(0,i);
+        norm_squared = norm_squared + U(0,i)*U(0,i);
       }
     break;
 
     case 2:
       for (int i = 0; i < n; i++) {
-        norm = norm + U(0,i)*U(0,i) + U(1,i)*U(1,i);
+        norm_squared = norm_squared + U(0,i)*U(0,i) + U(1,i)*U(1,i);
       }
     break;
 
     case 3:
       for (int i = 0; i < n; i++) {
-        norm = norm + U(0,i)*U(0,i) + U(1,i)*U(1,i) + U(2,i)*U(2,i);
+        norm_squared = norm_squared + U(0,i)*U(0,i) + U(1,i)*U(1,i) + U(2,i)*U(2,i);
       }
     break;
 
     case 4:
       for (int i = 0; i < n; i++) {
-        norm = norm + U(0,i)*U(0,i) + U(1,i)*U(1,i) + U(2,i)*U(2,i); + U(3,i)*U(3,i);
+        norm_squared = norm_squared + U(0,i)*U(0,i) + U(1,i)*U(1,i) + U(2,i)*U(2,i); + U(3,i)*U(3,i);
       }
     break;
 
     default: 
       for (int i = 0; i < n; i++) {
         for (int j = 0; i < m; i++) {
-          norm = norm + U(j,i)*U(j,i);
+          norm_squared = norm_squared + U(j,i)*U(j,i);
         }
       }
     break;
     }
 
-  return norm;
+  return norm_squared;
 }
 
 void print_mem(const std::string& type, const std::string& prefix, const double memory_in_use, const double memory_returned)

--- a/Code/Source/solver/utils.cpp
+++ b/Code/Source/solver/utils.cpp
@@ -225,39 +225,11 @@ double norm_squared(const Array<double>& U)
   int n = U.ncols();
   double norm_squared = 0.0;
 
-  switch (m) { 
-    case 1:
-      for (int i = 0; i < n; i++) {
-        norm_squared = norm_squared + U(0,i)*U(0,i);
-      }
-    break;
-
-    case 2:
-      for (int i = 0; i < n; i++) {
-        norm_squared = norm_squared + U(0,i)*U(0,i) + U(1,i)*U(1,i);
-      }
-    break;
-
-    case 3:
-      for (int i = 0; i < n; i++) {
-        norm_squared = norm_squared + U(0,i)*U(0,i) + U(1,i)*U(1,i) + U(2,i)*U(2,i);
-      }
-    break;
-
-    case 4:
-      for (int i = 0; i < n; i++) {
-        norm_squared = norm_squared + U(0,i)*U(0,i) + U(1,i)*U(1,i) + U(2,i)*U(2,i) + U(3,i)*U(3,i);
-      }
-    break;
-
-    default: 
-      for (int i = 0; i < n; i++) {
-        for (int j = 0; i < m; i++) {
-          norm_squared = norm_squared + U(j,i)*U(j,i);
-        }
-      }
-    break;
-    }
+  // Array::operator(const int) allows linear access into the 2D array elements,
+  // so that we can compute the norm by using a single for loop.
+  for (int i = 0; i < U.size(); ++i) {
+    norm_squared += U(i) * U(i);
+  }
 
   return norm_squared;
 }

--- a/Code/Source/solver/utils.h
+++ b/Code/Source/solver/utils.h
@@ -48,7 +48,7 @@ bool is_zero(double value1, double value2=0.0);
 double mem_usage(const bool print_usage=false, const std::string& prefix="");
 
 double norm_squared(const Vector<double>& U);
-double norm_squared(const Vector<double>& U, const Vector<double>& V);
+double dot(const Vector<double>& U, const Vector<double>& V);
 double norm_squared(const Array<double>& U);
 
 void print_mem(const std::string& type, const std::string& prefix, const double memory_in_use, const double memory_returned);

--- a/Code/Source/solver/utils.h
+++ b/Code/Source/solver/utils.h
@@ -47,9 +47,9 @@ bool is_zero(double value1, double value2=0.0);
 
 double mem_usage(const bool print_usage=false, const std::string& prefix="");
 
-double norm(const Vector<double>& U); 
-double norm(const Vector<double>& U, const Vector<double>& V);
-double norm(const Array<double>& U);
+double norm_squared(const Vector<double>& U);
+double norm_squared(const Vector<double>& U, const Vector<double>& V);
+double norm_squared(const Array<double>& U);
 
 void print_mem(const std::string& type, const std::string& prefix, const double memory_in_use, const double memory_returned);
 void print_stats(const std::string& type, const std::string& prefix, const int allocated, const int active);

--- a/Code/Source/solver/utils.h
+++ b/Code/Source/solver/utils.h
@@ -73,14 +73,6 @@ double norm(const Vector<double> &U);
  */
 double norm(const Array<double> &U);
 
-/**
- * @brief Compute the dot product of two vectors.
- *
- * The vectors are assumed to have the same size, and an exception is thrown if
- * they do not.
- */
-double dot(const Vector<double>& U, const Vector<double>& V);
-
 void print_mem(const std::string& type, const std::string& prefix, const double memory_in_use, const double memory_returned);
 void print_stats(const std::string& type, const std::string& prefix, const int allocated, const int active);
 

--- a/Code/Source/solver/utils.h
+++ b/Code/Source/solver/utils.h
@@ -50,6 +50,9 @@ double mem_usage(const bool print_usage=false, const std::string& prefix="");
 double norm_squared(const Vector<double>& U);
 double norm_squared(const Array<double>& U);
 
+double norm(const Vector<double> &U);
+double norm(const Array<double> &U);
+
 double dot(const Vector<double>& U, const Vector<double>& V);
 
 void print_mem(const std::string& type, const std::string& prefix, const double memory_in_use, const double memory_returned);

--- a/Code/Source/solver/utils.h
+++ b/Code/Source/solver/utils.h
@@ -48,8 +48,9 @@ bool is_zero(double value1, double value2=0.0);
 double mem_usage(const bool print_usage=false, const std::string& prefix="");
 
 double norm_squared(const Vector<double>& U);
-double dot(const Vector<double>& U, const Vector<double>& V);
 double norm_squared(const Array<double>& U);
+
+double dot(const Vector<double>& U, const Vector<double>& V);
 
 void print_mem(const std::string& type, const std::string& prefix, const double memory_in_use, const double memory_returned);
 void print_stats(const std::string& type, const std::string& prefix, const int allocated, const int active);

--- a/Code/Source/solver/utils.h
+++ b/Code/Source/solver/utils.h
@@ -47,12 +47,38 @@ bool is_zero(double value1, double value2=0.0);
 
 double mem_usage(const bool print_usage=false, const std::string& prefix="");
 
+/**
+ * @brief Compute the square of the Euclidean norm of a vector.
+ */
 double norm_squared(const Vector<double>& U);
+
+/**
+ * @brief Compute the square of the Frobenius norm of an array.
+ *
+ * The square of the Frobenius norm is the sum of the squares of all elements in
+ * the array.
+ */
 double norm_squared(const Array<double>& U);
 
+/**
+ * @brief Compute the Euclidean norm of a vector.
+ */
 double norm(const Vector<double> &U);
+
+/**
+ * @brief Compute the Frobenius norm of an array.
+ *
+ * The Frobenius norm is the square root of the sum of the squares of all
+ * elements in the array.
+ */
 double norm(const Array<double> &U);
 
+/**
+ * @brief Compute the dot product of two vectors.
+ *
+ * The vectors are assumed to have the same size, and an exception is thrown if
+ * they do not.
+ */
 double dot(const Vector<double>& U, const Vector<double>& V);
 
 void print_mem(const std::string& type, const std::string& prefix, const double memory_in_use, const double memory_returned);


### PR DESCRIPTION
## Current situation

Fixes #553.

Before this PR, the files `utils.h`/`utils.cpp` defined three functions named `norm`, of which:
1. `norm(const Vector<double>&)` and `norm(const Array<double> &)` computed the squared norm of their argument (Euclidean norm for `Vector`, Frobenius norm for `Array`);
2. `norm(const Vector<double>&, const Vector<double> &)` computed the scalar product of its arguments.

## Release Notes 

After this PR, in the same files:
1. `norm(const Vector<double>&)` and `norm(const Array<double>&)` are renamed to `norm_squared`;
2. `norm(const Vector<double>&, const Vector<double> &)` is renamed to `dot`, and throws an exception if the two arguments have different sizes;
3. two new functions `norm(const Vector<double> &)` and `norm(const Array<double> &)` are introduced to compute `sqrt(norm_squared(...))`.

## Documentation

All the functions modified or added have been given Doxygen-style documentation comments.

## Testing

I have manually ran the automatic tests to verify that no regression was introduced by these changes.

## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
