### PR TITLE
Include valve velocity in the URIS valve implementation

### DIFF
--- a/Code/Source/solver/ComMod.h
+++ b/Code/Source/solver/ComMod.h
@@ -1469,6 +1469,12 @@ class urisType
     // Valve surface position coordinates.
     Array<double> x;
 
+    // Valve position coordinates at the previous time step.
+    Array<double> x_prev;
+
+    // Valve velocity on the valve surface nodes.
+    Array<double> valve_velocity;
+
     // Valve displacement.
     Array<double> Yd;
 
@@ -1493,6 +1499,9 @@ class urisType
     // this assumption, this flag should be set to true to flip the normals.
     bool invert_normal;
 
+    // Whether to include the valve velocity in the RIS implementation. Default is false.
+    bool include_RIS_velocity;
+
     // Opening positions of the valve surfaces.
     Array3<double> DxOpen;
 
@@ -1508,8 +1517,14 @@ class urisType
     // Iteration count.
     int cnt = 1000000;
 
-    // Signed distance function indexed by fluid/background mesh node.
+    // Flag to indicate if the SDF is computed.
+    bool sdf_computed = false;
+
+    // Signed distance function indexed by backgroundfluid mesh node.
     Vector<double> sdf;
+
+    // Valve velocity interpolated on background fluid mesh nodes.
+    Array<double> valve_velocity_fluid;
 
     // Mesh scale factor.
     double scF;

--- a/Code/Source/solver/ComMod.h
+++ b/Code/Source/solver/ComMod.h
@@ -1500,7 +1500,7 @@ class urisType
     bool invert_normal;
 
     // Whether to include the valve velocity in the RIS implementation. Default is false.
-    bool include_RIS_velocity;
+    bool include_uris_velocity;
 
     // Opening positions of the valve surfaces.
     Array3<double> DxOpen;

--- a/Code/Source/solver/ComMod.h
+++ b/Code/Source/solver/ComMod.h
@@ -1500,7 +1500,7 @@ class urisType
     bool invert_normal;
 
     // Whether to include the valve velocity in the RIS implementation. Default is false.
-    bool include_uris_velocity;
+    bool include_uris_velocity = false;
 
     // Opening positions of the valve surfaces.
     Array3<double> DxOpen;

--- a/Code/Source/solver/Parameters.cpp
+++ b/Code/Source/solver/Parameters.cpp
@@ -2990,7 +2990,7 @@ URISMeshParameters::URISMeshParameters()
   set_parameter("Valve_starts_as_closed", true,  !required, valve_starts_as_closed);
   set_parameter("Invert_normal", false,  !required, invert_normal);
   set_parameter("Positive_flow_normal_file_path", "",  !required, positive_flow_normal_file_path);
-  set_parameter("Include_RIS_velocity", false,  !required, include_RIS_velocity);
+  set_parameter("Include_URIS_velocity", false,  !required, include_uris_velocity);
 }
 
 void URISMeshParameters::print_parameters()

--- a/Code/Source/solver/Parameters.cpp
+++ b/Code/Source/solver/Parameters.cpp
@@ -2990,6 +2990,7 @@ URISMeshParameters::URISMeshParameters()
   set_parameter("Valve_starts_as_closed", true,  !required, valve_starts_as_closed);
   set_parameter("Invert_normal", false,  !required, invert_normal);
   set_parameter("Positive_flow_normal_file_path", "",  !required, positive_flow_normal_file_path);
+  set_parameter("Include_RIS_velocity", false,  !required, include_RIS_velocity);
 }
 
 void URISMeshParameters::print_parameters()

--- a/Code/Source/solver/Parameters.h
+++ b/Code/Source/solver/Parameters.h
@@ -1786,7 +1786,7 @@ class URISMeshParameters : public ParameterLists
     Parameter<bool> valve_starts_as_closed; // Whether the valve starts as closed
     Parameter<bool> invert_normal; // Whether to invert the valve surface normal vector
     Parameter<std::string> positive_flow_normal_file_path; // File path for the positive flow normal
-
+    Parameter<bool> include_RIS_velocity; // Whether to include the RIS velocity
 };
 
 

--- a/Code/Source/solver/Parameters.h
+++ b/Code/Source/solver/Parameters.h
@@ -1786,7 +1786,7 @@ class URISMeshParameters : public ParameterLists
     Parameter<bool> valve_starts_as_closed; // Whether the valve starts as closed
     Parameter<bool> invert_normal; // Whether to invert the valve surface normal vector
     Parameter<std::string> positive_flow_normal_file_path; // File path for the positive flow normal
-    Parameter<bool> include_RIS_velocity; // Whether to include the RIS velocity
+    Parameter<bool> include_uris_velocity; // Whether to include the RIS velocity
 };
 
 

--- a/Code/Source/solver/distribute.cpp
+++ b/Code/Source/solver/distribute.cpp
@@ -1179,6 +1179,8 @@ void dist_uris(ComMod& com_mod, const CmMod& cm_mod, const cmType& cm) {
     cm.bcast(cm_mod, &uris[iUris].resistance);
     cm.bcast(cm_mod, &uris[iUris].clsFlg);
     cm.bcast(cm_mod, &uris[iUris].invert_normal);
+    cm.bcast(cm_mod, &uris[iUris].sdf_computed);
+    cm.bcast(cm_mod, &uris[iUris].include_RIS_velocity);
     cm.bcast(cm_mod, &uris[iUris].cnt);
     cm.bcast(cm_mod, &uris[iUris].scF);
     cm.bcast(cm_mod, uris[iUris].nrm);
@@ -1300,8 +1302,8 @@ void dist_uris(ComMod& com_mod, const CmMod& cm_mod, const cmType& cm) {
   int n;
   if (cm.mas(cm_mod)) {
     for (int iUris = 0; iUris < com_mod.nUris; iUris++) {
-      OpenN(iUris) = uris[iUris].DxOpen.nrows();
-      CloseN(iUris) = uris[iUris].DxClose.nrows();
+      OpenN(iUris) = uris[iUris].DxOpen.nslices();
+      CloseN(iUris) = uris[iUris].DxClose.nslices();
       DxOpenFlatSize(iUris) = uris[iUris].DxOpen.size();
       DxCloseFlatSize(iUris) = uris[iUris].DxClose.size();
       DxOpenFlat[iUris].resize(DxOpenFlatSize(iUris));
@@ -1334,12 +1336,16 @@ void dist_uris(ComMod& com_mod, const CmMod& cm_mod, const cmType& cm) {
 
   if (cm.slv(cm_mod)) {
     for (int iUris = 0; iUris < com_mod.nUris; iUris++) {
-      uris[iUris].DxOpen.resize(OpenN(iUris), com_mod.nsd, uris[iUris].tnNo);
-      uris[iUris].DxClose.resize(CloseN(iUris), com_mod.nsd, uris[iUris].tnNo);
+      uris[iUris].DxOpen.resize(com_mod.nsd, uris[iUris].tnNo, OpenN(iUris));
+      uris[iUris].DxClose.resize(com_mod.nsd, uris[iUris].tnNo, CloseN(iUris));
       uris[iUris].x.resize(com_mod.nsd, uris[iUris].tnNo);
       uris[iUris].Yd.resize(com_mod.nsd, uris[iUris].tnNo);
       DxOpenFlat[iUris].resize(DxOpenFlatSize(iUris));
       DxCloseFlat[iUris].resize(DxCloseFlatSize(iUris));
+      if (uris[iUris].include_RIS_velocity) {
+        uris[iUris].x_prev.resize(com_mod.nsd, uris[iUris].tnNo);
+        uris[iUris].valve_velocity.resize(com_mod.nsd, uris[iUris].tnNo);
+      }
     }
   }
 
@@ -1348,6 +1354,10 @@ void dist_uris(ComMod& com_mod, const CmMod& cm_mod, const cmType& cm) {
     cm.bcast(cm_mod, uris[iUris].Yd);
     cm.bcast(cm_mod, DxOpenFlat[iUris]);
     cm.bcast(cm_mod, DxCloseFlat[iUris]);
+    if (uris[iUris].include_RIS_velocity) {
+      cm.bcast(cm_mod, uris[iUris].x_prev);
+      cm.bcast(cm_mod, uris[iUris].valve_velocity);
+    }
   }
 
   if (cm.slv(cm_mod)) {

--- a/Code/Source/solver/distribute.cpp
+++ b/Code/Source/solver/distribute.cpp
@@ -1180,7 +1180,7 @@ void dist_uris(ComMod& com_mod, const CmMod& cm_mod, const cmType& cm) {
     cm.bcast(cm_mod, &uris[iUris].clsFlg);
     cm.bcast(cm_mod, &uris[iUris].invert_normal);
     cm.bcast(cm_mod, &uris[iUris].sdf_computed);
-    cm.bcast(cm_mod, &uris[iUris].include_RIS_velocity);
+    cm.bcast(cm_mod, &uris[iUris].include_uris_velocity);
     cm.bcast(cm_mod, &uris[iUris].cnt);
     cm.bcast(cm_mod, &uris[iUris].scF);
     cm.bcast(cm_mod, uris[iUris].nrm);
@@ -1342,7 +1342,7 @@ void dist_uris(ComMod& com_mod, const CmMod& cm_mod, const cmType& cm) {
       uris[iUris].Yd.resize(com_mod.nsd, uris[iUris].tnNo);
       DxOpenFlat[iUris].resize(DxOpenFlatSize(iUris));
       DxCloseFlat[iUris].resize(DxCloseFlatSize(iUris));
-      if (uris[iUris].include_RIS_velocity) {
+      if (uris[iUris].include_uris_velocity) {
         uris[iUris].x_prev.resize(com_mod.nsd, uris[iUris].tnNo);
         uris[iUris].valve_velocity.resize(com_mod.nsd, uris[iUris].tnNo);
       }
@@ -1354,7 +1354,7 @@ void dist_uris(ComMod& com_mod, const CmMod& cm_mod, const cmType& cm) {
     cm.bcast(cm_mod, uris[iUris].Yd);
     cm.bcast(cm_mod, DxOpenFlat[iUris]);
     cm.bcast(cm_mod, DxCloseFlat[iUris]);
-    if (uris[iUris].include_RIS_velocity) {
+    if (uris[iUris].include_uris_velocity) {
       cm.bcast(cm_mod, uris[iUris].x_prev);
       cm.bcast(cm_mod, uris[iUris].valve_velocity);
     }

--- a/Code/Source/solver/fluid.cpp
+++ b/Code/Source/solver/fluid.cpp
@@ -621,9 +621,10 @@ void construct_fluid(ComMod& com_mod, const mshType& lM, const SolutionStates& s
     Array<double> ksix(nsd,nsd);
     // Total resistance factor value of the RIS valves for the current element 
     // at different quadrature points
-    Vector<double> risFactorTotalEl;
+    Vector<double> urisFactorTotalEl;
+    Array<double> urisValveVelTotalEl;
     if (com_mod.urisFlag) {
-      uris::uris_compute_ris_factor(com_mod, lM, fs[0], e, risFactorTotalEl);
+      uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs[0], e, urisFactorTotalEl, urisValveVelTotalEl);
     }
 
     for (int g = 0; g < fs[0].nG; g++) {
@@ -661,12 +662,15 @@ void construct_fluid(ComMod& com_mod, const mshType& lM, const SolutionStates& s
         auto N0 = fs[0].N.rcol(g); 
         auto N1 = fs[1].N.rcol(g); 
         double risFactorTotal = 0.0;
+        Vector<double> risValveVelTotal(nsd);
+        risValveVelTotal = 0.0;
         if (com_mod.urisFlag) {
-          risFactorTotal = risFactorTotalEl(g);
+          risFactorTotal = urisFactorTotalEl(g);
+          risValveVelTotal = urisValveVelTotalEl.rcol(g);
         }
         fluid_3d_m(com_mod, vmsStab, fs[0].eNoN, fs[1].eNoN, w, ksix, N0, N1, 
             Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, K_inverse_darcy_permeability, 
-            risFactorTotal);
+            risFactorTotal, risValveVelTotal);
 
       } else if (nsd == 2) {
         auto N0 = fs[0].N.rcol(g); 
@@ -694,8 +698,8 @@ void construct_fluid(ComMod& com_mod, const mshType& lM, const SolutionStates& s
     // If the number of quadrature points is different for the continuity and 
     // momentum function spaces, recompute the RIS factor
     if (com_mod.urisFlag) {
-      if (static_cast<int>(risFactorTotalEl.size()) != fs[1].nG) {
-        uris::uris_compute_ris_factor(com_mod, lM, fs[1], e, risFactorTotalEl);
+      if (static_cast<int>(urisFactorTotalEl.size()) != fs[1].nG) {
+        uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs[1], e, urisFactorTotalEl, urisValveVelTotalEl);
       }
     }
 
@@ -725,12 +729,15 @@ void construct_fluid(ComMod& com_mod, const mshType& lM, const SolutionStates& s
         auto N0 = fs[0].N.rcol(g); 
         auto N1 = fs[1].N.rcol(g); 
         double risFactorTotal = 0.0;
+        Vector<double> risValveVelTotal(nsd);
+        risValveVelTotal = 0.0;
         if (com_mod.urisFlag) {
-          risFactorTotal = risFactorTotalEl(g);
+          risFactorTotal = urisFactorTotalEl(g);
+          risValveVelTotal = urisValveVelTotalEl.rcol(g);
         }
         fluid_3d_c(com_mod, vmsStab, fs[0].eNoN, fs[1].eNoN, w, ksix, N0, N1, 
               Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, K_inverse_darcy_permeability, 
-              risFactorTotal);
+              risFactorTotal, risValveVelTotal);
 
       } else if (nsd == 2) {
         auto N0 = fs[0].N.rcol(g); 
@@ -1439,7 +1446,7 @@ void fluid_3d_c(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
     const Array<double>& Kxi, const Vector<double>& Nw, const Vector<double>& Nq, const Array<double>& Nwx, 
     const Array<double>& Nqx, const Array<double>& Nwxx, const Array<double>& al, const Array<double>& yl, 
     const Array<double>& bfl, Array<double>& lR, Array3<double>& lK, double K_inverse_darcy_permeability, 
-    double risFactorTotal)
+    const double risFactorTotal, const Vector<double>& risValveVelTotal)
 {
   #define n_debug_fluid3d_c
   #ifdef debug_fluid3d_c
@@ -1682,11 +1689,11 @@ void fluid_3d_c(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
     // up[2] = -tauM*(rho*rV[2] + px[2] - rS[2] + mu*K_inverse_darcy_permeability*u[2]);
 
     up[0] = -tauM*(rho*rV[0] + px[0] - rS[0] + mu*K_inverse_darcy_permeability*u[0]
-                   + risFactorTotal*u[0]);
+                   + risFactorTotal*u[0] - risValveVelTotal[0]);
     up[1] = -tauM*(rho*rV[1] + px[1] - rS[1] + mu*K_inverse_darcy_permeability*u[1]
-                   + risFactorTotal*u[1]);
+                   + risFactorTotal*u[1] - risValveVelTotal[1]);
     up[2] = -tauM*(rho*rV[2] + px[2] - rS[2] + mu*K_inverse_darcy_permeability*u[2]
-                   + risFactorTotal*u[2]);
+                   + risFactorTotal*u[2] - risValveVelTotal[2]);
 
     for (int a = 0; a < eNoNw; a++) {
       double uNx = u[0]*Nwx(0,a) + u[1]*Nwx(1,a) + u[2]*Nwx(2,a);
@@ -1764,7 +1771,7 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
     const Array<double>& Kxi, const Vector<double>& Nw, const Vector<double>& Nq, const Array<double>& Nwx,
     const Array<double>& Nqx, const Array<double>& Nwxx, const Array<double>& al, const Array<double>& yl,
     const Array<double>& bfl, Array<double>& lR, Array3<double>& lK, double K_inverse_darcy_permeability, 
-    double risFactorTotal)
+    const double risFactorTotal, const Vector<double>& risValveVelTotal)
 {
   #define n_debug_fluid_3d_m
   #ifdef debug_fluid_3d_m
@@ -2035,11 +2042,11 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
   // up[2] = -tauM*(rho*rV[2] + px[2] - rS[2] + mu*K_inverse_darcy_permeability * u[2]);
 
   up[0] = -tauM*(rho*rV[0] + px[0] - rS[0] + mu*K_inverse_darcy_permeability * u[0]
-                 + risFactorTotal * u[0]);
+                 + risFactorTotal * u[0] - risValveVelTotal[0]);
   up[1] = -tauM*(rho*rV[1] + px[1] - rS[1] + mu*K_inverse_darcy_permeability * u[1]
-                 + risFactorTotal * u[1]);
+                 + risFactorTotal * u[1] - risValveVelTotal[1]);
   up[2] = -tauM*(rho*rV[2] + px[2] - rS[2] + mu*K_inverse_darcy_permeability * u[2]
-                 + risFactorTotal * u[2]);
+                 + risFactorTotal * u[2] - risValveVelTotal[2]);
 
   double tauC, tauB, pa;
   double eps = std::numeric_limits<double>::epsilon();
@@ -2222,11 +2229,11 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
   // Local residue
   for (int a = 0; a < eNoNw; a++) {
       lR(0,a) = lR(0,a) + mu*K_inverse_darcy_permeability*w*Nw(a)*(u[0]+up[0])
-                        + risFactorTotal*w*Nw(a)*u[0];
+                        + w*Nw(a)*(risFactorTotal*u[0] - risValveVelTotal[0]);
       lR(1,a) = lR(1,a) + mu*K_inverse_darcy_permeability*w*Nw(a)*(u[1]+up[1])
-                        + risFactorTotal*w*Nw(a)*u[1];
+                        + w*Nw(a)*(risFactorTotal*u[1] - risValveVelTotal[1]);
       lR(2,a) = lR(2,a) + mu*K_inverse_darcy_permeability*w*Nw(a)*(u[2]+up[2])
-                        + risFactorTotal*w*Nw(a)*u[2];
+                        + w*Nw(a)*(risFactorTotal*u[2] - risValveVelTotal[2]);
   }
 
 }

--- a/Code/Source/solver/fluid.cpp
+++ b/Code/Source/solver/fluid.cpp
@@ -622,9 +622,9 @@ void construct_fluid(ComMod& com_mod, const mshType& lM, const SolutionStates& s
     // Total resistance factor value of the RIS valves for the current element 
     // at different quadrature points
     Vector<double> urisFactorTotalEl;
-    Array<double> urisValveVelTotalEl;
+    Array<double> urisValveVelFactorlTotalEl;
     if (com_mod.urisFlag) {
-      uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs[0], e, urisFactorTotalEl, urisValveVelTotalEl);
+      uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs[0], e, urisFactorTotalEl, urisValveVelFactorlTotalEl);
     }
 
     for (int g = 0; g < fs[0].nG; g++) {
@@ -662,14 +662,14 @@ void construct_fluid(ComMod& com_mod, const mshType& lM, const SolutionStates& s
         auto N0 = fs[0].N.rcol(g); 
         auto N1 = fs[1].N.rcol(g); 
         double urisFactorTotal = 0.0;
-        Vector<double> urisValveVelTotal(nsd);
+        Vector<double> urisValveVelFactorlTotal(nsd);
         if (com_mod.urisFlag) {
           urisFactorTotal = urisFactorTotalEl(g);
-          urisValveVelTotal = urisValveVelTotalEl.rcol(g);
+          urisValveVelFactorlTotal = urisValveVelFactorlTotalEl.rcol(g);
         }
         fluid_3d_m(com_mod, vmsStab, fs[0].eNoN, fs[1].eNoN, w, ksix, N0, N1, 
             Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, K_inverse_darcy_permeability, 
-            urisFactorTotal, urisValveVelTotal);
+            urisFactorTotal, urisValveVelFactorlTotal);
 
       } else if (nsd == 2) {
         auto N0 = fs[0].N.rcol(g); 
@@ -698,7 +698,7 @@ void construct_fluid(ComMod& com_mod, const mshType& lM, const SolutionStates& s
     // momentum function spaces, recompute the RIS factor
     if (com_mod.urisFlag) {
       if (urisFactorTotalEl.size() != fs[1].nG) {
-        uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs[1], e, urisFactorTotalEl, urisValveVelTotalEl);
+        uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs[1], e, urisFactorTotalEl, urisValveVelFactorlTotalEl);
       }
     }
 
@@ -728,14 +728,14 @@ void construct_fluid(ComMod& com_mod, const mshType& lM, const SolutionStates& s
         auto N0 = fs[0].N.rcol(g); 
         auto N1 = fs[1].N.rcol(g); 
         double urisFactorTotal = 0.0;
-        Vector<double> urisValveVelTotal(nsd);
+        Vector<double> urisValveVelFactorlTotal(nsd);
         if (com_mod.urisFlag) {
           urisFactorTotal = urisFactorTotalEl(g);
-          urisValveVelTotal = urisValveVelTotalEl.rcol(g);
+          urisValveVelFactorlTotal = urisValveVelFactorlTotalEl.rcol(g);
         }
         fluid_3d_c(com_mod, vmsStab, fs[0].eNoN, fs[1].eNoN, w, ksix, N0, N1, 
               Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, K_inverse_darcy_permeability, 
-              urisFactorTotal, urisValveVelTotal);
+              urisFactorTotal, urisValveVelFactorlTotal);
 
       } else if (nsd == 2) {
         auto N0 = fs[0].N.rcol(g); 
@@ -1444,7 +1444,7 @@ void fluid_3d_c(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
     const Array<double>& Kxi, const Vector<double>& Nw, const Vector<double>& Nq, const Array<double>& Nwx, 
     const Array<double>& Nqx, const Array<double>& Nwxx, const Array<double>& al, const Array<double>& yl, 
     const Array<double>& bfl, Array<double>& lR, Array3<double>& lK, double K_inverse_darcy_permeability, 
-    const double urisFactorTotal, const Vector<double>& urisValveVelTotal)
+    const double urisFactorTotal, const Vector<double>& urisValveVelFactorlTotal)
 {
   #define n_debug_fluid3d_c
   #ifdef debug_fluid3d_c
@@ -1687,11 +1687,11 @@ void fluid_3d_c(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
     // up[2] = -tauM*(rho*rV[2] + px[2] - rS[2] + mu*K_inverse_darcy_permeability*u[2]);
 
     up[0] = -tauM*(rho*rV[0] + px[0] - rS[0] + mu*K_inverse_darcy_permeability*u[0]
-                   + urisFactorTotal*u[0] - urisValveVelTotal[0]);
+                   + urisFactorTotal*u[0] - urisValveVelFactorlTotal[0]);
     up[1] = -tauM*(rho*rV[1] + px[1] - rS[1] + mu*K_inverse_darcy_permeability*u[1]
-                   + urisFactorTotal*u[1] - urisValveVelTotal[1]);
+                   + urisFactorTotal*u[1] - urisValveVelFactorlTotal[1]);
     up[2] = -tauM*(rho*rV[2] + px[2] - rS[2] + mu*K_inverse_darcy_permeability*u[2]
-                   + urisFactorTotal*u[2] - urisValveVelTotal[2]);
+                   + urisFactorTotal*u[2] - urisValveVelFactorlTotal[2]);
 
     for (int a = 0; a < eNoNw; a++) {
       double uNx = u[0]*Nwx(0,a) + u[1]*Nwx(1,a) + u[2]*Nwx(2,a);
@@ -1769,7 +1769,7 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
     const Array<double>& Kxi, const Vector<double>& Nw, const Vector<double>& Nq, const Array<double>& Nwx,
     const Array<double>& Nqx, const Array<double>& Nwxx, const Array<double>& al, const Array<double>& yl,
     const Array<double>& bfl, Array<double>& lR, Array3<double>& lK, double K_inverse_darcy_permeability, 
-    const double urisFactorTotal, const Vector<double>& urisValveVelTotal)
+    const double urisFactorTotal, const Vector<double>& urisValveVelFactorlTotal)
 {
   #define n_debug_fluid_3d_m
   #ifdef debug_fluid_3d_m
@@ -2040,11 +2040,11 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
   // up[2] = -tauM*(rho*rV[2] + px[2] - rS[2] + mu*K_inverse_darcy_permeability * u[2]);
 
   up[0] = -tauM*(rho*rV[0] + px[0] - rS[0] + mu*K_inverse_darcy_permeability * u[0]
-                 + urisFactorTotal * u[0] - urisValveVelTotal[0]);
+                 + urisFactorTotal * u[0] - urisValveVelFactorlTotal[0]);
   up[1] = -tauM*(rho*rV[1] + px[1] - rS[1] + mu*K_inverse_darcy_permeability * u[1]
-                 + urisFactorTotal * u[1] - urisValveVelTotal[1]);
+                 + urisFactorTotal * u[1] - urisValveVelFactorlTotal[1]);
   up[2] = -tauM*(rho*rV[2] + px[2] - rS[2] + mu*K_inverse_darcy_permeability * u[2]
-                 + urisFactorTotal * u[2] - urisValveVelTotal[2]);
+                 + urisFactorTotal * u[2] - urisValveVelFactorlTotal[2]);
 
   double tauC, tauB, pa;
   double eps = std::numeric_limits<double>::epsilon();
@@ -2227,11 +2227,11 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
   // Local residue
   for (int a = 0; a < eNoNw; a++) {
       lR(0,a) = lR(0,a) + mu*K_inverse_darcy_permeability*w*Nw(a)*(u[0]+up[0])
-                        + w*Nw(a)*(urisFactorTotal*u[0] - urisValveVelTotal[0]);
+                        + w*Nw(a)*(urisFactorTotal*u[0] - urisValveVelFactorlTotal[0]);
       lR(1,a) = lR(1,a) + mu*K_inverse_darcy_permeability*w*Nw(a)*(u[1]+up[1])
-                        + w*Nw(a)*(urisFactorTotal*u[1] - urisValveVelTotal[1]);
+                        + w*Nw(a)*(urisFactorTotal*u[1] - urisValveVelFactorlTotal[1]);
       lR(2,a) = lR(2,a) + mu*K_inverse_darcy_permeability*w*Nw(a)*(u[2]+up[2])
-                        + w*Nw(a)*(urisFactorTotal*u[2] - urisValveVelTotal[2]);
+                        + w*Nw(a)*(urisFactorTotal*u[2] - urisValveVelFactorlTotal[2]);
   }
 
 }

--- a/Code/Source/solver/fluid.cpp
+++ b/Code/Source/solver/fluid.cpp
@@ -622,9 +622,9 @@ void construct_fluid(ComMod& com_mod, const mshType& lM, const SolutionStates& s
     // Total resistance factor value of the RIS valves for the current element 
     // at different quadrature points
     Vector<double> urisFactorTotalEl;
-    Array<double> urisValveVelFactorlTotalEl;
+    Array<double> urisValveVelTermTotalEl;
     if (com_mod.urisFlag) {
-      uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs[0], e, urisFactorTotalEl, urisValveVelFactorlTotalEl);
+      uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs[0], e, urisFactorTotalEl, urisValveVelTermTotalEl);
     }
 
     for (int g = 0; g < fs[0].nG; g++) {
@@ -662,14 +662,14 @@ void construct_fluid(ComMod& com_mod, const mshType& lM, const SolutionStates& s
         auto N0 = fs[0].N.rcol(g); 
         auto N1 = fs[1].N.rcol(g); 
         double urisFactorTotal = 0.0;
-        Vector<double> urisValveVelFactorlTotal(nsd);
+        Vector<double> urisValveVelTermTotal(nsd);
         if (com_mod.urisFlag) {
           urisFactorTotal = urisFactorTotalEl(g);
-          urisValveVelFactorlTotal = urisValveVelFactorlTotalEl.rcol(g);
+          urisValveVelTermTotal = urisValveVelTermTotalEl.rcol(g);
         }
         fluid_3d_m(com_mod, vmsStab, fs[0].eNoN, fs[1].eNoN, w, ksix, N0, N1, 
             Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, K_inverse_darcy_permeability, 
-            urisFactorTotal, urisValveVelFactorlTotal);
+            urisFactorTotal, urisValveVelTermTotal);
 
       } else if (nsd == 2) {
         auto N0 = fs[0].N.rcol(g); 
@@ -698,7 +698,7 @@ void construct_fluid(ComMod& com_mod, const mshType& lM, const SolutionStates& s
     // momentum function spaces, recompute the RIS factor
     if (com_mod.urisFlag) {
       if (urisFactorTotalEl.size() != fs[1].nG) {
-        uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs[1], e, urisFactorTotalEl, urisValveVelFactorlTotalEl);
+        uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs[1], e, urisFactorTotalEl, urisValveVelTermTotalEl);
       }
     }
 
@@ -728,14 +728,14 @@ void construct_fluid(ComMod& com_mod, const mshType& lM, const SolutionStates& s
         auto N0 = fs[0].N.rcol(g); 
         auto N1 = fs[1].N.rcol(g); 
         double urisFactorTotal = 0.0;
-        Vector<double> urisValveVelFactorlTotal(nsd);
+        Vector<double> urisValveVelTermTotal(nsd);
         if (com_mod.urisFlag) {
           urisFactorTotal = urisFactorTotalEl(g);
-          urisValveVelFactorlTotal = urisValveVelFactorlTotalEl.rcol(g);
+          urisValveVelTermTotal = urisValveVelTermTotalEl.rcol(g);
         }
         fluid_3d_c(com_mod, vmsStab, fs[0].eNoN, fs[1].eNoN, w, ksix, N0, N1, 
               Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, K_inverse_darcy_permeability, 
-              urisFactorTotal, urisValveVelFactorlTotal);
+              urisFactorTotal, urisValveVelTermTotal);
 
       } else if (nsd == 2) {
         auto N0 = fs[0].N.rcol(g); 
@@ -1444,7 +1444,7 @@ void fluid_3d_c(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
     const Array<double>& Kxi, const Vector<double>& Nw, const Vector<double>& Nq, const Array<double>& Nwx, 
     const Array<double>& Nqx, const Array<double>& Nwxx, const Array<double>& al, const Array<double>& yl, 
     const Array<double>& bfl, Array<double>& lR, Array3<double>& lK, double K_inverse_darcy_permeability, 
-    const double urisFactorTotal, const Vector<double>& urisValveVelFactorlTotal)
+    const double urisFactorTotal, const Vector<double>& urisValveVelTermTotal)
 {
   #define n_debug_fluid3d_c
   #ifdef debug_fluid3d_c
@@ -1687,11 +1687,11 @@ void fluid_3d_c(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
     // up[2] = -tauM*(rho*rV[2] + px[2] - rS[2] + mu*K_inverse_darcy_permeability*u[2]);
 
     up[0] = -tauM*(rho*rV[0] + px[0] - rS[0] + mu*K_inverse_darcy_permeability*u[0]
-                   + urisFactorTotal*u[0] - urisValveVelFactorlTotal[0]);
+                   + urisFactorTotal*u[0] - urisValveVelTermTotal[0]);
     up[1] = -tauM*(rho*rV[1] + px[1] - rS[1] + mu*K_inverse_darcy_permeability*u[1]
-                   + urisFactorTotal*u[1] - urisValveVelFactorlTotal[1]);
+                   + urisFactorTotal*u[1] - urisValveVelTermTotal[1]);
     up[2] = -tauM*(rho*rV[2] + px[2] - rS[2] + mu*K_inverse_darcy_permeability*u[2]
-                   + urisFactorTotal*u[2] - urisValveVelFactorlTotal[2]);
+                   + urisFactorTotal*u[2] - urisValveVelTermTotal[2]);
 
     for (int a = 0; a < eNoNw; a++) {
       double uNx = u[0]*Nwx(0,a) + u[1]*Nwx(1,a) + u[2]*Nwx(2,a);
@@ -1769,7 +1769,7 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
     const Array<double>& Kxi, const Vector<double>& Nw, const Vector<double>& Nq, const Array<double>& Nwx,
     const Array<double>& Nqx, const Array<double>& Nwxx, const Array<double>& al, const Array<double>& yl,
     const Array<double>& bfl, Array<double>& lR, Array3<double>& lK, double K_inverse_darcy_permeability, 
-    const double urisFactorTotal, const Vector<double>& urisValveVelFactorlTotal)
+    const double urisFactorTotal, const Vector<double>& urisValveVelTermTotal)
 {
   #define n_debug_fluid_3d_m
   #ifdef debug_fluid_3d_m
@@ -2040,11 +2040,11 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
   // up[2] = -tauM*(rho*rV[2] + px[2] - rS[2] + mu*K_inverse_darcy_permeability * u[2]);
 
   up[0] = -tauM*(rho*rV[0] + px[0] - rS[0] + mu*K_inverse_darcy_permeability * u[0]
-                 + urisFactorTotal * u[0] - urisValveVelFactorlTotal[0]);
+                 + urisFactorTotal * u[0] - urisValveVelTermTotal[0]);
   up[1] = -tauM*(rho*rV[1] + px[1] - rS[1] + mu*K_inverse_darcy_permeability * u[1]
-                 + urisFactorTotal * u[1] - urisValveVelFactorlTotal[1]);
+                 + urisFactorTotal * u[1] - urisValveVelTermTotal[1]);
   up[2] = -tauM*(rho*rV[2] + px[2] - rS[2] + mu*K_inverse_darcy_permeability * u[2]
-                 + urisFactorTotal * u[2] - urisValveVelFactorlTotal[2]);
+                 + urisFactorTotal * u[2] - urisValveVelTermTotal[2]);
 
   double tauC, tauB, pa;
   double eps = std::numeric_limits<double>::epsilon();
@@ -2227,11 +2227,11 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
   // Local residue
   for (int a = 0; a < eNoNw; a++) {
       lR(0,a) = lR(0,a) + mu*K_inverse_darcy_permeability*w*Nw(a)*(u[0]+up[0])
-                        + w*Nw(a)*(urisFactorTotal*u[0] - urisValveVelFactorlTotal[0]);
+                        + w*Nw(a)*(urisFactorTotal*u[0] - urisValveVelTermTotal[0]);
       lR(1,a) = lR(1,a) + mu*K_inverse_darcy_permeability*w*Nw(a)*(u[1]+up[1])
-                        + w*Nw(a)*(urisFactorTotal*u[1] - urisValveVelFactorlTotal[1]);
+                        + w*Nw(a)*(urisFactorTotal*u[1] - urisValveVelTermTotal[1]);
       lR(2,a) = lR(2,a) + mu*K_inverse_darcy_permeability*w*Nw(a)*(u[2]+up[2])
-                        + w*Nw(a)*(urisFactorTotal*u[2] - urisValveVelFactorlTotal[2]);
+                        + w*Nw(a)*(urisFactorTotal*u[2] - urisValveVelTermTotal[2]);
   }
 
 }

--- a/Code/Source/solver/fluid.cpp
+++ b/Code/Source/solver/fluid.cpp
@@ -661,16 +661,15 @@ void construct_fluid(ComMod& com_mod, const mshType& lM, const SolutionStates& s
       if (nsd == 3) {
         auto N0 = fs[0].N.rcol(g); 
         auto N1 = fs[1].N.rcol(g); 
-        double risFactorTotal = 0.0;
-        Vector<double> risValveVelTotal(nsd);
-        risValveVelTotal = 0.0;
+        double urisFactorTotal = 0.0;
+        Vector<double> urisValveVelTotal(nsd);
         if (com_mod.urisFlag) {
-          risFactorTotal = urisFactorTotalEl(g);
-          risValveVelTotal = urisValveVelTotalEl.rcol(g);
+          urisFactorTotal = urisFactorTotalEl(g);
+          urisValveVelTotal = urisValveVelTotalEl.rcol(g);
         }
         fluid_3d_m(com_mod, vmsStab, fs[0].eNoN, fs[1].eNoN, w, ksix, N0, N1, 
             Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, K_inverse_darcy_permeability, 
-            risFactorTotal, risValveVelTotal);
+            urisFactorTotal, urisValveVelTotal);
 
       } else if (nsd == 2) {
         auto N0 = fs[0].N.rcol(g); 
@@ -728,16 +727,15 @@ void construct_fluid(ComMod& com_mod, const mshType& lM, const SolutionStates& s
       if (nsd == 3) {
         auto N0 = fs[0].N.rcol(g); 
         auto N1 = fs[1].N.rcol(g); 
-        double risFactorTotal = 0.0;
-        Vector<double> risValveVelTotal(nsd);
-        risValveVelTotal = 0.0;
+        double urisFactorTotal = 0.0;
+        Vector<double> urisValveVelTotal(nsd);
         if (com_mod.urisFlag) {
-          risFactorTotal = urisFactorTotalEl(g);
-          risValveVelTotal = urisValveVelTotalEl.rcol(g);
+          urisFactorTotal = urisFactorTotalEl(g);
+          urisValveVelTotal = urisValveVelTotalEl.rcol(g);
         }
         fluid_3d_c(com_mod, vmsStab, fs[0].eNoN, fs[1].eNoN, w, ksix, N0, N1, 
               Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, K_inverse_darcy_permeability, 
-              risFactorTotal, risValveVelTotal);
+              urisFactorTotal, urisValveVelTotal);
 
       } else if (nsd == 2) {
         auto N0 = fs[0].N.rcol(g); 
@@ -1446,7 +1444,7 @@ void fluid_3d_c(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
     const Array<double>& Kxi, const Vector<double>& Nw, const Vector<double>& Nq, const Array<double>& Nwx, 
     const Array<double>& Nqx, const Array<double>& Nwxx, const Array<double>& al, const Array<double>& yl, 
     const Array<double>& bfl, Array<double>& lR, Array3<double>& lK, double K_inverse_darcy_permeability, 
-    const double risFactorTotal, const Vector<double>& risValveVelTotal)
+    const double urisFactorTotal, const Vector<double>& urisValveVelTotal)
 {
   #define n_debug_fluid3d_c
   #ifdef debug_fluid3d_c
@@ -1661,7 +1659,7 @@ void fluid_3d_c(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
     
     // In case of unfitted RIS, compute the delta function at the quad point,
     // add the additional value to the stabilization param 
-    kT = kT + pow(risFactorTotal, 2.0);
+    kT = kT + pow(urisFactorTotal, 2.0);
 
     double kU = u[0]*u[0]*Kxi(0,0) + u[1]*u[0]*Kxi(1,0) + u[2]*u[0]*Kxi(2,0)
               + u[0]*u[1]*Kxi(0,1) + u[1]*u[1]*Kxi(1,1) + u[2]*u[1]*Kxi(2,1)
@@ -1689,11 +1687,11 @@ void fluid_3d_c(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
     // up[2] = -tauM*(rho*rV[2] + px[2] - rS[2] + mu*K_inverse_darcy_permeability*u[2]);
 
     up[0] = -tauM*(rho*rV[0] + px[0] - rS[0] + mu*K_inverse_darcy_permeability*u[0]
-                   + risFactorTotal*u[0] - risValveVelTotal[0]);
+                   + urisFactorTotal*u[0] - urisValveVelTotal[0]);
     up[1] = -tauM*(rho*rV[1] + px[1] - rS[1] + mu*K_inverse_darcy_permeability*u[1]
-                   + risFactorTotal*u[1] - risValveVelTotal[1]);
+                   + urisFactorTotal*u[1] - urisValveVelTotal[1]);
     up[2] = -tauM*(rho*rV[2] + px[2] - rS[2] + mu*K_inverse_darcy_permeability*u[2]
-                   + risFactorTotal*u[2] - risValveVelTotal[2]);
+                   + urisFactorTotal*u[2] - urisValveVelTotal[2]);
 
     for (int a = 0; a < eNoNw; a++) {
       double uNx = u[0]*Nwx(0,a) + u[1]*Nwx(1,a) + u[2]*Nwx(2,a);
@@ -1702,7 +1700,7 @@ void fluid_3d_c(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
       T1 = -rho*uNx + mu*(Nwxx(0,a) + Nwxx(1,a) + Nwxx(2,a)) 
            + mu_x[0]*Nwx(0,a) + mu_x[1]*Nwx(1,a) + mu_x[2]*Nwx(2,a) 
            - mu*K_inverse_darcy_permeability*Nw(a)
-           - risFactorTotal*Nw(a);
+           - urisFactorTotal*Nw(a);
 
       updu[0][0][a] = mu_x[0]*Nwx(0,a) + d2u2[0]*mu_g*esNx[0][a] + T1;
       updu[1][0][a] = mu_x[1]*Nwx(0,a) + d2u2[1]*mu_g*esNx[0][a];
@@ -1771,7 +1769,7 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
     const Array<double>& Kxi, const Vector<double>& Nw, const Vector<double>& Nq, const Array<double>& Nwx,
     const Array<double>& Nqx, const Array<double>& Nwxx, const Array<double>& al, const Array<double>& yl,
     const Array<double>& bfl, Array<double>& lR, Array3<double>& lK, double K_inverse_darcy_permeability, 
-    const double risFactorTotal, const Vector<double>& risValveVelTotal)
+    const double urisFactorTotal, const Vector<double>& urisValveVelTotal)
 {
   #define n_debug_fluid_3d_m
   #ifdef debug_fluid_3d_m
@@ -2007,7 +2005,7 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
 
   // In case of unfitted RIS, compute the delta function at the quad point,
   // add the additional value to the stabilization param 
-  kT = kT + pow(risFactorTotal, 2.0);
+  kT = kT + pow(urisFactorTotal, 2.0);
 
   double kU = u[0]*u[0]*Kxi(0,0) + u[1]*u[0]*Kxi(1,0) + u[2]*u[0]*Kxi(2,0)
             + u[0]*u[1]*Kxi(0,1) + u[1]*u[1]*Kxi(1,1) + u[2]*u[1]*Kxi(2,1)
@@ -2042,11 +2040,11 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
   // up[2] = -tauM*(rho*rV[2] + px[2] - rS[2] + mu*K_inverse_darcy_permeability * u[2]);
 
   up[0] = -tauM*(rho*rV[0] + px[0] - rS[0] + mu*K_inverse_darcy_permeability * u[0]
-                 + risFactorTotal * u[0] - risValveVelTotal[0]);
+                 + urisFactorTotal * u[0] - urisValveVelTotal[0]);
   up[1] = -tauM*(rho*rV[1] + px[1] - rS[1] + mu*K_inverse_darcy_permeability * u[1]
-                 + risFactorTotal * u[1] - risValveVelTotal[1]);
+                 + urisFactorTotal * u[1] - urisValveVelTotal[1]);
   up[2] = -tauM*(rho*rV[2] + px[2] - rS[2] + mu*K_inverse_darcy_permeability * u[2]
-                 + risFactorTotal * u[2] - risValveVelTotal[2]);
+                 + urisFactorTotal * u[2] - urisValveVelTotal[2]);
 
   double tauC, tauB, pa;
   double eps = std::numeric_limits<double>::epsilon();
@@ -2128,7 +2126,7 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
     T1 = -rho*uNx[a] + mu*(Nwxx(0,a) + Nwxx(1,a) + Nwxx(2,a)) 
          + mu_x[0]*Nwx(0,a) + mu_x[1]*Nwx(1,a) + mu_x[2]*Nwx(2,a) 
          - mu*K_inverse_darcy_permeability*Nw(a)
-         - risFactorTotal*Nw(a);
+         - urisFactorTotal*Nw(a);
 
     updu[0][0][a] = mu_x[0]*Nwx(0,a) + d2u2[0]*mu_g*esNx[0][a] + T1;
     updu[1][0][a] = mu_x[1]*Nwx(0,a) + d2u2[1]*mu_g*esNx[0][a];
@@ -2165,7 +2163,7 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
       lK(0,a,b)  = lK(0,a,b)  + wl*(T2 + T1);
       // lK(0,a,b)  = lK(0,a,b)  + mu*K_inverse_darcy_permeability*wl*Nw(b)*Nw(a);
       lK(0,a,b)  = lK(0,a,b)  + mu*K_inverse_darcy_permeability*wl*Nw(b)*Nw(a)
-                              + risFactorTotal*wl*Nw(b)*Nw(a);
+                              + urisFactorTotal*wl*Nw(b)*Nw(a);
 
       // dRm_a1/du_b2
       T2 = mu*rM[1][0] + tauC*rM[0][1] + esNx[0][a]*mu_g*esNx[1][b] - rho*tauM*uaNx[a]*updu[1][0][b];
@@ -2184,7 +2182,7 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
       lK(5,a,b)  = lK(5,a,b)  + wl*(T2 + T1);
       // lK(5,a,b)  = lK(5,a,b)  + mu*K_inverse_darcy_permeability*wl*Nw(b)*Nw(a);
       lK(5,a,b)  = lK(5,a,b)  + mu*K_inverse_darcy_permeability*wl*Nw(b)*Nw(a)
-                              + risFactorTotal*wl*Nw(b)*Nw(a);
+                              + urisFactorTotal*wl*Nw(b)*Nw(a);
 
       // dRm_a2/du_b3
       T2 = mu*rM[2][1] + tauC*rM[1][2] + esNx[1][a]*mu_g*esNx[2][b] - rho*tauM*uaNx[a]*updu[2][1][b];
@@ -2203,7 +2201,7 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
       lK(10,a,b) = lK(10,a,b) + wl*(T2 + T1);
       // lK(10,a,b) = lK(10,a,b) + mu*K_inverse_darcy_permeability*wl*Nw(b)*Nw(a);
       lK(10,a,b) = lK(10,a,b) + mu*K_inverse_darcy_permeability*wl*Nw(b)*Nw(a)
-                              + risFactorTotal*wl*Nw(b)*Nw(a);
+                              + urisFactorTotal*wl*Nw(b)*Nw(a);
       //dmsg << "lK(10,a,b): " << lK(10,a,b);
     }
   }
@@ -2229,11 +2227,11 @@ void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
   // Local residue
   for (int a = 0; a < eNoNw; a++) {
       lR(0,a) = lR(0,a) + mu*K_inverse_darcy_permeability*w*Nw(a)*(u[0]+up[0])
-                        + w*Nw(a)*(risFactorTotal*u[0] - risValveVelTotal[0]);
+                        + w*Nw(a)*(urisFactorTotal*u[0] - urisValveVelTotal[0]);
       lR(1,a) = lR(1,a) + mu*K_inverse_darcy_permeability*w*Nw(a)*(u[1]+up[1])
-                        + w*Nw(a)*(risFactorTotal*u[1] - risValveVelTotal[1]);
+                        + w*Nw(a)*(urisFactorTotal*u[1] - urisValveVelTotal[1]);
       lR(2,a) = lR(2,a) + mu*K_inverse_darcy_permeability*w*Nw(a)*(u[2]+up[2])
-                        + w*Nw(a)*(risFactorTotal*u[2] - risValveVelTotal[2]);
+                        + w*Nw(a)*(urisFactorTotal*u[2] - urisValveVelTotal[2]);
   }
 
 }

--- a/Code/Source/solver/fluid.cpp
+++ b/Code/Source/solver/fluid.cpp
@@ -697,7 +697,7 @@ void construct_fluid(ComMod& com_mod, const mshType& lM, const SolutionStates& s
     // If the number of quadrature points is different for the continuity and 
     // momentum function spaces, recompute the RIS factor
     if (com_mod.urisFlag) {
-      if (static_cast<int>(urisFactorTotalEl.size()) != fs[1].nG) {
+      if (urisFactorTotalEl.size() != fs[1].nG) {
         uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs[1], e, urisFactorTotalEl, urisValveVelTotalEl);
       }
     }

--- a/Code/Source/solver/fluid.h
+++ b/Code/Source/solver/fluid.h
@@ -36,12 +36,14 @@ void fluid_2d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
 void fluid_3d_c(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int eNoNq, const double w, const Array<double>& Kxi, 
     const Vector<double>& Nw, const Vector<double>& Nq, const Array<double>& Nwx, const Array<double>& Nqx, 
     const Array<double>& Nwxx, const Array<double>& al, const Array<double>& yl, const Array<double>& bfl, 
-    Array<double>& lR, Array3<double>& lK, double K_inverse_darcy_permeability, double risFactorTotal);
+    Array<double>& lR, Array3<double>& lK, double K_inverse_darcy_permeability, 
+    const double risFactorTotal, const Vector<double>& risValveVelTotal);
 
 void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int eNoNq, const double w, const Array<double>& Kxi, 
     const Vector<double>& Nw, const Vector<double>& Nq, const Array<double>& Nwx, const Array<double>& Nqx, 
     const Array<double>& Nwxx, const Array<double>& al, const Array<double>& yl, const Array<double>& bfl, 
-    Array<double>& lR, Array3<double>& lK, double K_inverse_darcy_permeability, double risFactorTotal);
+    Array<double>& lR, Array3<double>& lK, double K_inverse_darcy_permeability, 
+    const double risFactorTotal, const Vector<double>& risValveVelTotal);
 
 void get_viscosity(const ComMod& com_mod, const dmnType& lDmn, double& gamma, double& mu, double& mu_s, double& mu_x);
 

--- a/Code/Source/solver/fluid.h
+++ b/Code/Source/solver/fluid.h
@@ -37,13 +37,13 @@ void fluid_3d_c(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int e
     const Vector<double>& Nw, const Vector<double>& Nq, const Array<double>& Nwx, const Array<double>& Nqx, 
     const Array<double>& Nwxx, const Array<double>& al, const Array<double>& yl, const Array<double>& bfl, 
     Array<double>& lR, Array3<double>& lK, double K_inverse_darcy_permeability, 
-    const double risFactorTotal, const Vector<double>& risValveVelTotal);
+    const double urisFactorTotal, const Vector<double>& urisValveVelTotal);
 
 void fluid_3d_m(ComMod& com_mod, const int vmsFlag, const int eNoNw, const int eNoNq, const double w, const Array<double>& Kxi, 
     const Vector<double>& Nw, const Vector<double>& Nq, const Array<double>& Nwx, const Array<double>& Nqx, 
     const Array<double>& Nwxx, const Array<double>& al, const Array<double>& yl, const Array<double>& bfl, 
     Array<double>& lR, Array3<double>& lK, double K_inverse_darcy_permeability, 
-    const double risFactorTotal, const Vector<double>& risValveVelTotal);
+    const double urisFactorTotal, const Vector<double>& urisValveVelTotal);
 
 void get_viscosity(const ComMod& com_mod, const dmnType& lDmn, double& gamma, double& mu, double& mu_s, double& mu_x);
 

--- a/Code/Source/solver/fsi.cpp
+++ b/Code/Source/solver/fsi.cpp
@@ -167,9 +167,10 @@ void construct_fsi(ComMod& com_mod, CepMod& cep_mod, const mshType& lM, const So
     Array<double> ksix(nsd,nsd);
     // Total resistance factor value of the RIS valves for the current element 
     // at different quadrature points
-    Vector<double> risFactorTotalEl;
+    Vector<double> urisFactorTotalEl;
+    Array<double> urisValveVelTotalEl;
     if (com_mod.urisFlag) {
-      uris::uris_compute_ris_factor(com_mod, lM, fs_1[0], e, risFactorTotalEl);
+      uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs_1[0], e, urisFactorTotalEl, urisValveVelTotalEl);
     }
 
     for (int g = 0; g < fs_1[0].nG; g++) {
@@ -200,12 +201,15 @@ void construct_fsi(ComMod& com_mod, CepMod& cep_mod, const mshType& lM, const So
             auto N0 = fs_1[0].N.col(g);
             auto N1 = fs_1[1].N.col(g);
             double risFactorTotal = 0.0;
+            Vector<double> risValveVelTotal(nsd);
+            risValveVelTotal = 0.0;
             if (com_mod.urisFlag) {
-              risFactorTotal = risFactorTotalEl(g);
+              risFactorTotal = urisFactorTotalEl(g);
+              risValveVelTotal = urisValveVelTotalEl.rcol(g);
             }
             
             // using zero permeability to use Navier-Stokes here, not Navier-Stokes-Brinkman
-            fluid::fluid_3d_m(com_mod, vmsStab, fs_1[0].eNoN, fs_1[1].eNoN, w, ksix, N0, N1, Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, 0.0, risFactorTotal);
+            fluid::fluid_3d_m(com_mod, vmsStab, fs_1[0].eNoN, fs_1[1].eNoN, w, ksix, N0, N1, Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, 0.0, risFactorTotal, risValveVelTotal);
 
           } break;
 
@@ -256,8 +260,8 @@ void construct_fsi(ComMod& com_mod, CepMod& cep_mod, const mshType& lM, const So
     // If the number of quadrature points is different for the continuity and 
     // momentum function spaces, recompute the RIS factor
     if (com_mod.urisFlag) {
-      if (static_cast<int>(risFactorTotalEl.size()) != fs_2[1].nG) {
-        uris::uris_compute_ris_factor(com_mod, lM, fs_2[1], e, risFactorTotalEl);
+      if (static_cast<int>(urisFactorTotalEl.size()) != fs_2[1].nG) {
+        uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs_2[1], e, urisFactorTotalEl, urisValveVelTotalEl);
       }
     }
 
@@ -289,12 +293,15 @@ void construct_fsi(ComMod& com_mod, CepMod& cep_mod, const mshType& lM, const So
             auto N0 = fs_2[0].N.col(g);
             auto N1 = fs_2[1].N.col(g);
             double risFactorTotal = 0.0;
+            Vector<double> risValveVelTotal(nsd);
+            risValveVelTotal = 0.0;
             if (com_mod.urisFlag) {
-              risFactorTotal = risFactorTotalEl(g);
+              risValveVelTotal = urisValveVelTotalEl.rcol(g);
+              risFactorTotal = urisFactorTotalEl(g);
             }
             
             // using zero permeability to use Navier-Stokes here, not Navier-Stokes-Brinkman
-            fluid::fluid_3d_c(com_mod, vmsStab, fs_2[0].eNoN, fs_2[1].eNoN, w, ksix, N0, N1, Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, 0.0, risFactorTotal);
+            fluid::fluid_3d_c(com_mod, vmsStab, fs_2[0].eNoN, fs_2[1].eNoN, w, ksix, N0, N1, Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, 0.0, risFactorTotal, risValveVelTotal);
           } break;
 
           case Equation_ustruct:

--- a/Code/Source/solver/fsi.cpp
+++ b/Code/Source/solver/fsi.cpp
@@ -200,16 +200,15 @@ void construct_fsi(ComMod& com_mod, CepMod& cep_mod, const mshType& lM, const So
           case Equation_fluid: {
             auto N0 = fs_1[0].N.col(g);
             auto N1 = fs_1[1].N.col(g);
-            double risFactorTotal = 0.0;
-            Vector<double> risValveVelTotal(nsd);
-            risValveVelTotal = 0.0;
+            double urisFactorTotal = 0.0;
+            Vector<double> urisValveVelTotal(nsd);
             if (com_mod.urisFlag) {
-              risFactorTotal = urisFactorTotalEl(g);
-              risValveVelTotal = urisValveVelTotalEl.rcol(g);
+              urisFactorTotal = urisFactorTotalEl(g);
+              urisValveVelTotal = urisValveVelTotalEl.rcol(g);
             }
             
             // using zero permeability to use Navier-Stokes here, not Navier-Stokes-Brinkman
-            fluid::fluid_3d_m(com_mod, vmsStab, fs_1[0].eNoN, fs_1[1].eNoN, w, ksix, N0, N1, Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, 0.0, risFactorTotal, risValveVelTotal);
+            fluid::fluid_3d_m(com_mod, vmsStab, fs_1[0].eNoN, fs_1[1].eNoN, w, ksix, N0, N1, Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, 0.0, urisFactorTotal, urisValveVelTotal);
 
           } break;
 
@@ -292,16 +291,15 @@ void construct_fsi(ComMod& com_mod, CepMod& cep_mod, const mshType& lM, const So
           case Equation_fluid: {
             auto N0 = fs_2[0].N.col(g);
             auto N1 = fs_2[1].N.col(g);
-            double risFactorTotal = 0.0;
-            Vector<double> risValveVelTotal(nsd);
-            risValveVelTotal = 0.0;
+            double urisFactorTotal = 0.0;
+            Vector<double> urisValveVelTotal(nsd);
             if (com_mod.urisFlag) {
-              risValveVelTotal = urisValveVelTotalEl.rcol(g);
-              risFactorTotal = urisFactorTotalEl(g);
+              urisValveVelTotal = urisValveVelTotalEl.rcol(g);
+              urisFactorTotal = urisFactorTotalEl(g);
             }
             
             // using zero permeability to use Navier-Stokes here, not Navier-Stokes-Brinkman
-            fluid::fluid_3d_c(com_mod, vmsStab, fs_2[0].eNoN, fs_2[1].eNoN, w, ksix, N0, N1, Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, 0.0, risFactorTotal, risValveVelTotal);
+            fluid::fluid_3d_c(com_mod, vmsStab, fs_2[0].eNoN, fs_2[1].eNoN, w, ksix, N0, N1, Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, 0.0, urisFactorTotal, urisValveVelTotal);
           } break;
 
           case Equation_ustruct:

--- a/Code/Source/solver/fsi.cpp
+++ b/Code/Source/solver/fsi.cpp
@@ -168,9 +168,9 @@ void construct_fsi(ComMod& com_mod, CepMod& cep_mod, const mshType& lM, const So
     // Total resistance factor value of the RIS valves for the current element 
     // at different quadrature points
     Vector<double> urisFactorTotalEl;
-    Array<double> urisValveVelTotalEl;
+    Array<double> urisValveVelFactorTotalEl;
     if (com_mod.urisFlag) {
-      uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs_1[0], e, urisFactorTotalEl, urisValveVelTotalEl);
+      uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs_1[0], e, urisFactorTotalEl, urisValveVelFactorTotalEl);
     }
 
     for (int g = 0; g < fs_1[0].nG; g++) {
@@ -201,14 +201,14 @@ void construct_fsi(ComMod& com_mod, CepMod& cep_mod, const mshType& lM, const So
             auto N0 = fs_1[0].N.col(g);
             auto N1 = fs_1[1].N.col(g);
             double urisFactorTotal = 0.0;
-            Vector<double> urisValveVelTotal(nsd);
+            Vector<double> urisValveVelFactorTotal(nsd);
             if (com_mod.urisFlag) {
               urisFactorTotal = urisFactorTotalEl(g);
-              urisValveVelTotal = urisValveVelTotalEl.rcol(g);
+              urisValveVelFactorTotal = urisValveVelFactorTotalEl.rcol(g);
             }
             
             // using zero permeability to use Navier-Stokes here, not Navier-Stokes-Brinkman
-            fluid::fluid_3d_m(com_mod, vmsStab, fs_1[0].eNoN, fs_1[1].eNoN, w, ksix, N0, N1, Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, 0.0, urisFactorTotal, urisValveVelTotal);
+            fluid::fluid_3d_m(com_mod, vmsStab, fs_1[0].eNoN, fs_1[1].eNoN, w, ksix, N0, N1, Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, 0.0, urisFactorTotal, urisValveVelFactorTotal);
 
           } break;
 
@@ -260,7 +260,7 @@ void construct_fsi(ComMod& com_mod, CepMod& cep_mod, const mshType& lM, const So
     // momentum function spaces, recompute the RIS factor
     if (com_mod.urisFlag) {
       if (urisFactorTotalEl.size() != fs_2[1].nG) {
-        uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs_2[1], e, urisFactorTotalEl, urisValveVelTotalEl);
+        uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs_2[1], e, urisFactorTotalEl, urisValveVelFactorTotalEl);
       }
     }
 
@@ -292,14 +292,14 @@ void construct_fsi(ComMod& com_mod, CepMod& cep_mod, const mshType& lM, const So
             auto N0 = fs_2[0].N.col(g);
             auto N1 = fs_2[1].N.col(g);
             double urisFactorTotal = 0.0;
-            Vector<double> urisValveVelTotal(nsd);
+            Vector<double> urisValveVelFactorTotal(nsd);
             if (com_mod.urisFlag) {
-              urisValveVelTotal = urisValveVelTotalEl.rcol(g);
               urisFactorTotal = urisFactorTotalEl(g);
+              urisValveVelFactorTotal = urisValveVelFactorTotalEl.rcol(g);
             }
             
             // using zero permeability to use Navier-Stokes here, not Navier-Stokes-Brinkman
-            fluid::fluid_3d_c(com_mod, vmsStab, fs_2[0].eNoN, fs_2[1].eNoN, w, ksix, N0, N1, Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, 0.0, urisFactorTotal, urisValveVelTotal);
+            fluid::fluid_3d_c(com_mod, vmsStab, fs_2[0].eNoN, fs_2[1].eNoN, w, ksix, N0, N1, Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, 0.0, urisFactorTotal, urisValveVelFactorTotal);
           } break;
 
           case Equation_ustruct:

--- a/Code/Source/solver/fsi.cpp
+++ b/Code/Source/solver/fsi.cpp
@@ -168,9 +168,9 @@ void construct_fsi(ComMod& com_mod, CepMod& cep_mod, const mshType& lM, const So
     // Total resistance factor value of the RIS valves for the current element 
     // at different quadrature points
     Vector<double> urisFactorTotalEl;
-    Array<double> urisValveVelFactorTotalEl;
+    Array<double> urisValveVelTermTotalEl;
     if (com_mod.urisFlag) {
-      uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs_1[0], e, urisFactorTotalEl, urisValveVelFactorTotalEl);
+      uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs_1[0], e, urisFactorTotalEl, urisValveVelTermTotalEl);
     }
 
     for (int g = 0; g < fs_1[0].nG; g++) {
@@ -201,14 +201,14 @@ void construct_fsi(ComMod& com_mod, CepMod& cep_mod, const mshType& lM, const So
             auto N0 = fs_1[0].N.col(g);
             auto N1 = fs_1[1].N.col(g);
             double urisFactorTotal = 0.0;
-            Vector<double> urisValveVelFactorTotal(nsd);
+            Vector<double> urisValveVelTermTotal(nsd);
             if (com_mod.urisFlag) {
               urisFactorTotal = urisFactorTotalEl(g);
-              urisValveVelFactorTotal = urisValveVelFactorTotalEl.rcol(g);
+              urisValveVelTermTotal = urisValveVelTermTotalEl.rcol(g);
             }
             
             // using zero permeability to use Navier-Stokes here, not Navier-Stokes-Brinkman
-            fluid::fluid_3d_m(com_mod, vmsStab, fs_1[0].eNoN, fs_1[1].eNoN, w, ksix, N0, N1, Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, 0.0, urisFactorTotal, urisValveVelFactorTotal);
+            fluid::fluid_3d_m(com_mod, vmsStab, fs_1[0].eNoN, fs_1[1].eNoN, w, ksix, N0, N1, Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, 0.0, urisFactorTotal, urisValveVelTermTotal);
 
           } break;
 
@@ -260,7 +260,7 @@ void construct_fsi(ComMod& com_mod, CepMod& cep_mod, const mshType& lM, const So
     // momentum function spaces, recompute the RIS factor
     if (com_mod.urisFlag) {
       if (urisFactorTotalEl.size() != fs_2[1].nG) {
-        uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs_2[1], e, urisFactorTotalEl, urisValveVelFactorTotalEl);
+        uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs_2[1], e, urisFactorTotalEl, urisValveVelTermTotalEl);
       }
     }
 
@@ -292,14 +292,14 @@ void construct_fsi(ComMod& com_mod, CepMod& cep_mod, const mshType& lM, const So
             auto N0 = fs_2[0].N.col(g);
             auto N1 = fs_2[1].N.col(g);
             double urisFactorTotal = 0.0;
-            Vector<double> urisValveVelFactorTotal(nsd);
+            Vector<double> urisValveVelTermTotal(nsd);
             if (com_mod.urisFlag) {
               urisFactorTotal = urisFactorTotalEl(g);
-              urisValveVelFactorTotal = urisValveVelFactorTotalEl.rcol(g);
+              urisValveVelTermTotal = urisValveVelTermTotalEl.rcol(g);
             }
             
             // using zero permeability to use Navier-Stokes here, not Navier-Stokes-Brinkman
-            fluid::fluid_3d_c(com_mod, vmsStab, fs_2[0].eNoN, fs_2[1].eNoN, w, ksix, N0, N1, Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, 0.0, urisFactorTotal, urisValveVelFactorTotal);
+            fluid::fluid_3d_c(com_mod, vmsStab, fs_2[0].eNoN, fs_2[1].eNoN, w, ksix, N0, N1, Nwx, Nqx, Nwxx, al, yl, bfl, lR, lK, 0.0, urisFactorTotal, urisValveVelTermTotal);
           } break;
 
           case Equation_ustruct:

--- a/Code/Source/solver/fsi.cpp
+++ b/Code/Source/solver/fsi.cpp
@@ -259,7 +259,7 @@ void construct_fsi(ComMod& com_mod, CepMod& cep_mod, const mshType& lM, const So
     // If the number of quadrature points is different for the continuity and 
     // momentum function spaces, recompute the RIS factor
     if (com_mod.urisFlag) {
-      if (static_cast<int>(urisFactorTotalEl.size()) != fs_2[1].nG) {
+      if (urisFactorTotalEl.size() != fs_2[1].nG) {
         uris::eval_uris_ris_factors_quadrature(com_mod, lM, fs_2[1], e, urisFactorTotalEl, urisValveVelTotalEl);
       }
     }

--- a/Code/Source/solver/initialize.cpp
+++ b/Code/Source/solver/initialize.cpp
@@ -888,7 +888,7 @@ void initialize(Simulation* simulation, Vector<double>& timeP)
       uris_obj.sdf.resize(com_mod.tnNo);
       uris_obj.sdf = uris_obj.sdf_default;
       uris_obj.sdf_computed = false;
-      if (uris_obj.include_RIS_velocity && !uris_obj.valve_velocity_fluid.allocated()) {
+      if (uris_obj.include_uris_velocity && !uris_obj.valve_velocity_fluid.allocated()) {
         uris_obj.valve_velocity_fluid.resize(nsd, com_mod.tnNo);
         uris_obj.valve_velocity_fluid = 0.0;
       }

--- a/Code/Source/solver/initialize.cpp
+++ b/Code/Source/solver/initialize.cpp
@@ -882,6 +882,19 @@ void initialize(Simulation* simulation, Vector<double>& timeP)
   std::fill(com_mod.rmsh.flag.begin(), com_mod.rmsh.flag.end(), false);
   com_mod.resetSim = false;
 
+  if (com_mod.urisFlag) {
+    for (int iUris = 0; iUris < com_mod.nUris; iUris++) {
+      auto& uris_obj = com_mod.uris[iUris];
+      uris_obj.sdf.resize(com_mod.tnNo);
+      uris_obj.sdf = uris_obj.sdf_default;
+      uris_obj.sdf_computed = false;
+      if (uris_obj.include_RIS_velocity && !uris_obj.valve_velocity_fluid.allocated()) {
+        uris_obj.valve_velocity_fluid.resize(nsd, com_mod.tnNo);
+        uris_obj.valve_velocity_fluid = 0.0;
+      }
+    }
+  }
+
   // Create Integrator now that initial_solutions (Ao, Do, Yo) are fully initialized
   // The Integrator takes ownership via move semantics
   simulation->initialize_integrator(std::move(initial_solutions));

--- a/Code/Source/solver/uris.cpp
+++ b/Code/Source/solver/uris.cpp
@@ -135,7 +135,7 @@ void uris_meanp(ComMod& com_mod, CmMod& cm_mod, const int iUris, const SolutionS
   }
 
   //  If the uris has passed the closing state
-  if (uris_obj.cnt > uris_obj.DxClose.nrows()) {
+  if (uris_obj.cnt > uris_obj.DxClose.nslices()) {
     if (uris_obj.meanPU > uris_obj.meanPD) {
       uris_obj.cnt = 1;
       uris_obj.clsFlg = false;
@@ -226,7 +226,7 @@ void uris_meanv(ComMod& com_mod, CmMod& cm_mod, const int iUris, const SolutionS
   }
 
   // If the uris has passed the open state
-  if (uris_obj.cnt > uris_obj.DxOpen.nrows()) {
+  if (uris_obj.cnt > uris_obj.DxOpen.nslices()) {
     if (meanV < 0.0) {
       uris_obj.cnt = 1;
       uris_obj.clsFlg = true;
@@ -365,9 +365,9 @@ void uris_find_tetra(ComMod& com_mod, CmMod& cm_mod, const int iUris) {
   // We need to check if the valve needs to move
   int cnt;
   if (!uris_obj.clsFlg) {
-    cnt = std::min(uris_obj.cnt, uris_obj.DxOpen.nrows());
+    cnt = std::min(uris_obj.cnt, uris_obj.DxOpen.nslices());
   } else {
-    cnt = std::min(uris_obj.cnt, uris_obj.DxClose.nrows());
+    cnt = std::min(uris_obj.cnt, uris_obj.DxClose.nslices());
   }
 
   if (uris_obj.elemId.allocated() && cnt < uris_obj.cnt) {
@@ -600,6 +600,7 @@ void uris_read_msh(Simulation* simulation) {
     uris_obj.resistance = param->resistance();
     uris_obj.clsFlg = param->valve_starts_as_closed();
     uris_obj.invert_normal = param->invert_normal();
+    uris_obj.include_RIS_velocity = param->include_RIS_velocity();
 
     // uris_obj.tnNo = 0;
     for (int iM = 0; iM < uris_obj.nFa; iM++) {
@@ -648,11 +649,11 @@ void uris_read_msh(Simulation* simulation) {
         throw std::runtime_error("Mismatch in node numbers between URIS mesh and displacements.");
       }
 
-      Array3<double> dispOpen(dispNtOpen, nsd, dispNnOpen);
-      for (int t = 0; t < dispNtOpen; t++) {
-        for (int a = 0; a < dispNnOpen; a++) {
+      Array3<double> dispOpen(nsd, dispNnOpen, dispNtOpen);
+      for (int k = 0; k < dispNtOpen; k++) {
+        for (int j = 0; j < dispNnOpen; j++) {
           for (int i = 0; i < nsd; i++) {
-            file_stream >> dispOpen(t,i,a);
+            file_stream >> dispOpen(i,j,k);
           }
         }
       }
@@ -674,11 +675,11 @@ void uris_read_msh(Simulation* simulation) {
         throw std::runtime_error("Mismatch in node numbers between URIS mesh and displacements.");
       }
 
-      Array3<double> dispClose(dispNtClose, nsd, dispNnClose);
-      for (int t = 0; t < dispNtClose; t++) {
-        for (int a = 0; a < dispNnClose; a++) {
+      Array3<double> dispClose(nsd, dispNnClose, dispNtClose);
+      for (int k = 0; k < dispNtClose; k++) {
+        for (int j = 0; j < dispNnClose; j++) {
           for (int i = 0; i < nsd; i++) {
-            file_stream >> dispClose(t,i,a);
+            file_stream >> dispClose(i,j,k);
           }
         }
       }
@@ -686,15 +687,12 @@ void uris_read_msh(Simulation* simulation) {
 
       // To scale the mesh, while attaching x to gX
       int a = uris_obj.tnNo + mesh.gnNo;
-      // std::cout << "uris obj tnNo: " << uris_obj.tnNo << std::endl;
-      // std::cout << "mesh gnNo: " << mesh.gnNo << std::endl;
-      // std::cout << "mesh x size: " << mesh.x.nrows() << ", " << mesh.x.ncols() << std::endl;
 
       if (iM == 0) {
         gX.resize(nsd, a);
         gX = 0.0;
-        uris_obj.DxOpen.resize(dispNtOpen, nsd, a);
-        uris_obj.DxClose.resize(dispNtClose, nsd, a);
+        uris_obj.DxOpen.resize(nsd, a, dispNtOpen);
+        uris_obj.DxClose.resize(nsd, a, dispNtClose);
       } else{
         Array<double> tmpX(nsd, uris_obj.tnNo);
         tmpX = gX;
@@ -704,18 +702,26 @@ void uris_read_msh(Simulation* simulation) {
         }
 
         // Move data for open
-        Array3<double> tmpDxOpen(dispNtOpen, nsd, uris_obj.tnNo);
+        Array3<double> tmpDxOpen(nsd, uris_obj.tnNo, dispNtOpen);
         tmpDxOpen = uris_obj.DxOpen;
-        uris_obj.DxOpen.resize(dispNtOpen, nsd, a);
-        for (int i = 0; i < uris_obj.tnNo; i++) {
-          uris_obj.DxOpen.rslice(i) = tmpDxOpen.rslice(i);
+        uris_obj.DxOpen.resize(nsd, a, dispNtOpen);
+        for (int i = 0; i < dispNtOpen; i++) {
+          for (int j = 0; j < uris_obj.tnNo; j++) {
+            for (int k = 0; k < nsd; k++) {
+              uris_obj.DxOpen(k,j,i) = tmpDxOpen(k,j,i);
+            }
+          }
         }
-        // Move data for open
-        Array3<double> tmpDxClose(dispNtClose, nsd, uris_obj.tnNo);
+        // Move data for close
+        Array3<double> tmpDxClose(nsd, uris_obj.tnNo, dispNtClose);
         tmpDxClose = uris_obj.DxClose;
-        uris_obj.DxClose.resize(dispNtClose, nsd, a);
-        for (int i = 0; i < uris_obj.tnNo; i++) {
-          uris_obj.DxClose.rslice(i) = tmpDxClose.rslice(i);
+        uris_obj.DxClose.resize(nsd, a, dispNtClose);
+        for (int i = 0; i < dispNtClose; i++) {
+          for (int j = 0; j < uris_obj.tnNo; j++) {
+            for (int k = 0; k < nsd; k++) {
+              uris_obj.DxClose(k,j,i) = tmpDxClose(k,j,i);
+            }
+          }
         }
       }
 
@@ -723,21 +729,43 @@ void uris_read_msh(Simulation* simulation) {
         gX.rcol(i) = mesh.x.rcol(i-uris_obj.tnNo) * uris_obj.scF;
       }
 
-      for (int i = uris_obj.tnNo; i < a; i++) {
-        uris_obj.DxOpen.rslice(i) = dispOpen.rslice(i-uris_obj.tnNo) * uris_obj.scF;
+      for (int k = 0; k < dispNtOpen; k++) {
+        for (int j = uris_obj.tnNo; j < a; j++) {
+          for (int i = 0; i < nsd; i++) {
+            uris_obj.DxOpen(i,j,k) = dispOpen(i,j-uris_obj.tnNo,k) * uris_obj.scF;
+          }
+        }
       }
 
-      for (int i = uris_obj.tnNo; i < a; i++) {
-        uris_obj.DxClose.rslice(i) = dispClose.rslice(i-uris_obj.tnNo) * uris_obj.scF;
+      for (int k = 0; k < dispNtClose; k++) {
+        for (int j = uris_obj.tnNo; j < a; j++) {
+          for (int i = 0; i < nsd; i++) {
+            uris_obj.DxClose(i,j,k) = dispClose(i,j-uris_obj.tnNo,k) * uris_obj.scF;
+          }
+        }
       }
+
       uris_obj.tnNo = a;
     }
-    
+
     uris_obj.x.resize(nsd, uris_obj.tnNo);
-    uris_obj.x = gX;
+    // Set the valve position in the initial position
+    if (uris_obj.clsFlg) {
+      int dispNtClose = uris_obj.DxClose.nslices();
+      uris_obj.x = uris_obj.DxClose.rslice(dispNtClose-1);
+    } else {
+      int dispNtOpen = uris_obj.DxOpen.nslices();
+      uris_obj.x = uris_obj.DxOpen.rslice(dispNtOpen-1);
+    }
     uris_obj.Yd.resize(nsd, uris_obj.tnNo);
     uris_obj.Yd = 0.0;
-    // gX.clear();
+
+    if (uris_obj.include_RIS_velocity) {
+      uris_obj.x_prev.resize(nsd, uris_obj.tnNo);
+      uris_obj.x_prev = uris_obj.x;
+      uris_obj.valve_velocity.resize(nsd, uris_obj.tnNo);
+      uris_obj.valve_velocity = 0.0;
+    }
 
     // Setting mesh.gN, mesh.lN parameter
     int b = 0;
@@ -955,36 +983,38 @@ void uris_calc_sdf(ComMod& com_mod) {
   }
 
   for (int iUris = 0; iUris < nUris; iUris++) {
-    // We need to check if the valve needs to move 
+    // First check if the valve needs to move 
     auto& uris_obj = uris[iUris];
-    int cnt = 0;
-    if (!uris_obj.clsFlg) {
-      cnt = std::min(uris_obj.cnt, uris_obj.DxOpen.nrows());
-      for (int i = 0; i < uris_obj.x.nrows(); i++) {
-        for (int j = 0; j < uris_obj.x.ncols(); j++) {
-          uris_obj.x(i,j) = uris_obj.DxOpen(cnt-1,i,j);
-        }
-      }
-    } else {
-      cnt = std::min(uris_obj.cnt, uris_obj.DxClose.nrows());
-      for (int i = 0; i < uris_obj.x.nrows(); i++) {
-        for (int j = 0; j < uris_obj.x.ncols(); j++) {
-          uris_obj.x(i,j) = uris_obj.DxClose(cnt-1,i,j);
-        }
-      }
-    }
-    
-    if (uris_obj.sdf.size() > 0 && cnt < uris_obj.cnt) {continue;}
 
-    if (uris_obj.sdf.size() <= 0) {
-      uris_obj.sdf.resize(com_mod.tnNo);
-      uris_obj.sdf = 0.0;
+    const Array3<double>& Dx = uris_obj.clsFlg ? uris_obj.DxClose : uris_obj.DxOpen;
+    int cnt = std::min(uris_obj.cnt, Dx.nslices());
+    uris_obj.x = Dx.rslice(cnt - 1);
+
+    if (uris_obj.include_RIS_velocity) {
+      if (cnt < uris_obj.cnt) {
+        // Frozen at last frame: valve not changing
+        uris_obj.x_prev = uris_obj.x;
+      } else if (cnt > 1) {
+        // Mid-motion: previous prescribed frame
+        uris_obj.x_prev = Dx.rslice(cnt - 2);
+      } else {
+        // cnt == 1: first frame of sequence
+        uris_obj.x_prev = uris_obj.x;
+      }
+      for (int i = 0; i < uris_obj.tnNo; i++) {
+        uris_obj.valve_velocity.rcol(i) = (uris_obj.x.rcol(i) - uris_obj.x_prev.rcol(i)) / com_mod.dt;
+      }
+      uris_obj.valve_velocity_fluid = 0.0;
     }
 
+    if (cnt < uris_obj.cnt && uris_obj.sdf_computed) {
+      continue;
+    }
+    uris_obj.sdf = uris_obj.sdf_default;
+  
     if (cm.idcm() == 0) {
       std::cout << "Recomputing SDF for " << uris_obj.name << std::endl;
     }
-    uris_obj.sdf = uris_obj.sdf_default;
 
     // Each time when the URIS moves (open/close), we need to 
     // recompute the signed distance function.
@@ -1051,8 +1081,16 @@ void uris_calc_sdf(ComMod& com_mod) {
 
       uris_obj.sdf[ca] = sdf_sign * minS;
 
-    }
-  }
+      if (uris_obj.include_RIS_velocity) {
+        Vector<double> interp_valve_vel(nsd);
+        uris_interp_valve_velocity(uris_obj, xp, nsd, jM, Ec, dotp, unitNormal, interp_valve_vel);
+        uris_obj.valve_velocity_fluid.rcol(ca) = interp_valve_vel;
+      }
+
+    } // ca: loop
+    uris_obj.sdf_computed = true;
+  } // iUris: loop
+
 }
 
 
@@ -1281,11 +1319,62 @@ double uris_compute_sdf_sign(const urisType& uris_obj, const Vector<double>& xp,
   return (dotP < 0.0) ? -1.0 : 1.0;
 }
 
-/// @brief Compute the RIS factor for the current element  at different quadrature points
-void uris_compute_ris_factor(const ComMod& com_mod, const mshType& lM, const fsType& fs, 
-  const int e, Vector<double>& ris_factor_total_el) {
-  #define n_dbg_uris_compute_ris_factor
-  #ifdef dbg_uris_compute_ris_factor
+
+/// @brief Interpolate valve velocity to fluid node at the given point xp
+void uris_interp_valve_velocity(const urisType& uris_obj, const Vector<double>& xp, const int nsd, 
+                                const int jM, const int Ec, const double dotP, 
+                                const Vector<double>& unitNormal, Vector<double>& interp_valve_vel) {
+  #define n_dbg_uris_interp_valve_velocity
+  #ifdef dbg_uris_interp_valve_velocity
+    DebugMsg dmsg(__func__, 0);
+    dmsg.banner();
+    dmsg << "interpolating valve velocity";
+  #endif
+
+  const auto& mesh = uris_obj.msh[jM];                          
+  Vector<double> xp_plane(nsd), E1(nsd), E2(nsd), v(nsd);
+  Array<double> lX(nsd, mesh.eNoN);
+
+  for (int a = 0; a < mesh.eNoN; a++) {
+    const int Ac = mesh.IEN(a, Ec);
+    lX.rcol(a) = uris_obj.x.rcol(Ac);
+  }
+  
+  // project xp onto the triangle plane
+  xp_plane = xp - dotP * unitNormal;
+  
+  // compute barycentric coordinates (xi, eta)
+  E1 = lX.rcol(1) - lX.rcol(0);
+  E2 = lX.rcol(2) - lX.rcol(0);
+  v = xp_plane - lX.rcol(0);
+
+  auto g11 = utils::norm(E1, E1);
+  auto g12 = utils::norm(E1, E2); 
+  auto g22 = utils::norm(E2, E2);
+  auto b1 = utils::norm(v, E1);
+  auto b2 = utils::norm(v, E2);
+  double det = g11 * g22 - g12 * g12;
+
+  double xi = (g22 * b1 - g12 * b2) / det;
+  double eta = (g11 * b2 - g12 * b1) / det;
+
+  // shape functions:
+  double N1 = 1.0 - xi - eta;
+  double N2 = xi;
+  double N3 = eta;
+
+  // interpolate the valve velocity:
+  interp_valve_vel = N1 * uris_obj.valve_velocity.rcol(mesh.IEN(0,Ec)) +
+                     N2 * uris_obj.valve_velocity.rcol(mesh.IEN(1,Ec)) +
+                     N3 * uris_obj.valve_velocity.rcol(mesh.IEN(2,Ec));
+  
+}
+
+/// @brief Evaluate total Brinkman factor and weighted valve velocity at element quadrature points.
+void eval_uris_ris_factors_quadrature(const ComMod& com_mod, const mshType& lM, const fsType& fs, 
+  const int e, Vector<double>& ris_factor_total_el, Array<double>& ris_valve_vel_total_el) {
+  #define n_dbg_eval_uris_ris_factors_quadrature
+  #ifdef dbg_eval_uris_ris_factors_quadrature
     DebugMsg dmsg(__func__, 0);
     dmsg.banner();
     dmsg << "computing RIS factor";
@@ -1294,14 +1383,27 @@ void uris_compute_ris_factor(const ComMod& com_mod, const mshType& lM, const fsT
   const int nUris = com_mod.nUris;
   ris_factor_total_el.resize(fs.nG);
   ris_factor_total_el = 0.0;
+  ris_valve_vel_total_el.resize(com_mod.nsd, fs.nG);
+  ris_valve_vel_total_el = 0.0;
+
+  if (!com_mod.urisActFlag) {
+    return;
+  }
+
   Vector<double> dist_srf(nUris);
+  Array<double> valve_velocity(com_mod.nsd, nUris);
 
   for (int g = 0; g < fs.nG; g++) {
     dist_srf = 0.0;
+    valve_velocity = 0.0;
     for (int a = 0; a < fs.eNoN; a++) {
       int Ac = lM.IEN(a,e);
       for (int iUris = 0; iUris < nUris; iUris++) {
         dist_srf(iUris) += fs.N(a,g) * std::fabs(com_mod.uris[iUris].sdf(Ac));
+        if (com_mod.uris[iUris].include_RIS_velocity) {
+          valve_velocity.rcol(iUris) = valve_velocity.rcol(iUris) +
+              fs.N(a,g) * com_mod.uris[iUris].valve_velocity_fluid.rcol(Ac);
+        }
       }
     }
 
@@ -1315,11 +1417,11 @@ void uris_compute_ris_factor(const ComMod& com_mod, const mshType& lM, const fsT
       if (com_mod.uris[iUris].clsFlg) {
         start_deps = com_mod.uris[iUris].sdf_deps;
         end_deps   = com_mod.uris[iUris].sdf_deps_close;
-        n_steps  = com_mod.uris[iUris].DxClose.nrows();
+        n_steps  = com_mod.uris[iUris].DxClose.nslices();
       } else {
         start_deps = com_mod.uris[iUris].sdf_deps_close;
         end_deps   = com_mod.uris[iUris].sdf_deps;
-        n_steps  = com_mod.uris[iUris].DxOpen.nrows();
+        n_steps  = com_mod.uris[iUris].DxOpen.nslices();
       }
 
       if (n_steps <= 0) {
@@ -1340,10 +1442,13 @@ void uris_compute_ris_factor(const ComMod& com_mod, const mshType& lM, const fsT
         delta_eps = (1 + cos(consts::pi*dist_srf(iUris)/sdf_deps))/(2*sdf_deps*sdf_deps);
       }
       ris_factor_total_el(g) += com_mod.uris[iUris].resistance * delta_eps;
-    } // iUris: loop
 
-    if (!com_mod.urisActFlag) {ris_factor_total_el(g) = 0.0;}
-  }
+      if (com_mod.uris[iUris].include_RIS_velocity) {
+        ris_valve_vel_total_el.rcol(g) = ris_valve_vel_total_el.rcol(g) 
+          + com_mod.uris[iUris].resistance * delta_eps*valve_velocity.rcol(iUris);
+      }
+    } // iUris: loop
+  } // g: loop
 }
 
 }

--- a/Code/Source/solver/uris.cpp
+++ b/Code/Source/solver/uris.cpp
@@ -600,7 +600,7 @@ void uris_read_msh(Simulation* simulation) {
     uris_obj.resistance = param->resistance();
     uris_obj.clsFlg = param->valve_starts_as_closed();
     uris_obj.invert_normal = param->invert_normal();
-    uris_obj.include_RIS_velocity = param->include_RIS_velocity();
+    uris_obj.include_uris_velocity = param->include_uris_velocity();
 
     // uris_obj.tnNo = 0;
     for (int iM = 0; iM < uris_obj.nFa; iM++) {
@@ -760,7 +760,7 @@ void uris_read_msh(Simulation* simulation) {
     uris_obj.Yd.resize(nsd, uris_obj.tnNo);
     uris_obj.Yd = 0.0;
 
-    if (uris_obj.include_RIS_velocity) {
+    if (uris_obj.include_uris_velocity) {
       uris_obj.x_prev.resize(nsd, uris_obj.tnNo);
       uris_obj.x_prev = uris_obj.x;
       uris_obj.valve_velocity.resize(nsd, uris_obj.tnNo);
@@ -990,7 +990,7 @@ void uris_calc_sdf(ComMod& com_mod) {
     int cnt = std::min(uris_obj.cnt, Dx.nslices());
     uris_obj.x = Dx.rslice(cnt - 1);
 
-    if (uris_obj.include_RIS_velocity) {
+    if (uris_obj.include_uris_velocity) {
       if (cnt < uris_obj.cnt) {
         // Frozen at last frame: valve not changing
         uris_obj.x_prev = uris_obj.x;
@@ -1081,7 +1081,7 @@ void uris_calc_sdf(ComMod& com_mod) {
 
       uris_obj.sdf[ca] = sdf_sign * minS;
 
-      if (uris_obj.include_RIS_velocity) {
+      if (uris_obj.include_uris_velocity) {
         Vector<double> interp_valve_vel(nsd);
         uris_interp_valve_velocity(uris_obj, xp, nsd, jM, Ec, dotp, unitNormal, interp_valve_vel);
         uris_obj.valve_velocity_fluid.rcol(ca) = interp_valve_vel;
@@ -1400,7 +1400,7 @@ void eval_uris_ris_factors_quadrature(const ComMod& com_mod, const mshType& lM, 
       int Ac = lM.IEN(a,e);
       for (int iUris = 0; iUris < nUris; iUris++) {
         dist_srf(iUris) += fs.N(a,g) * std::fabs(com_mod.uris[iUris].sdf(Ac));
-        if (com_mod.uris[iUris].include_RIS_velocity) {
+        if (com_mod.uris[iUris].include_uris_velocity) {
           valve_velocity.rcol(iUris) = valve_velocity.rcol(iUris) +
               fs.N(a,g) * com_mod.uris[iUris].valve_velocity_fluid.rcol(Ac);
         }
@@ -1443,7 +1443,7 @@ void eval_uris_ris_factors_quadrature(const ComMod& com_mod, const mshType& lM, 
       }
       ris_factor_total_el(g) += com_mod.uris[iUris].resistance * delta_eps;
 
-      if (com_mod.uris[iUris].include_RIS_velocity) {
+      if (com_mod.uris[iUris].include_uris_velocity) {
         ris_valve_vel_total_el.rcol(g) = ris_valve_vel_total_el.rcol(g) 
           + com_mod.uris[iUris].resistance * delta_eps*valve_velocity.rcol(iUris);
       }

--- a/Code/Source/solver/uris.cpp
+++ b/Code/Source/solver/uris.cpp
@@ -589,6 +589,12 @@ void uris_read_msh(Simulation* simulation) {
     }
     for (int i = 0; i < nsd; i++) {
       file_stream >> uris_obj.nrm(i);
+      if (!file_stream) {
+        throw std::runtime_error(
+            "Failed to read positive flow normal (component=" + std::to_string(i)
+            + ") from positive flow normal file '"
+            + positive_flow_normal_file_path + "'.");
+      }
     }
     file_stream.close();
 
@@ -642,6 +648,11 @@ void uris_read_msh(Simulation* simulation) {
       }
       int dispNtOpen, dispNnOpen;
       file_stream >> dispNtOpen >> dispNnOpen;
+      if (!file_stream) {
+        throw std::runtime_error(
+            "Failed to read time steps and node numbers from open motion file '"
+            + open_motion_file_path + "'.");
+      }
       // std::cout << "dispNtOpen: " << dispNtOpen << std::endl;
       // std::cout << "dispNnOpen: " << dispNnOpen << std::endl;
 
@@ -654,6 +665,14 @@ void uris_read_msh(Simulation* simulation) {
         for (int j = 0; j < dispNnOpen; j++) {
           for (int i = 0; i < nsd; i++) {
             file_stream >> dispOpen(i,j,k);
+            if (!file_stream) {
+              throw std::runtime_error(
+                  "Failed to read displacement (time=" + std::to_string(k)
+                  + ", node=" + std::to_string(j)
+                  + ", component=" + std::to_string(i)
+                  + ") from open motion file '"
+                  + open_motion_file_path + "'.");
+            }
           }
         }
       }
@@ -668,6 +687,11 @@ void uris_read_msh(Simulation* simulation) {
       }
       int dispNtClose, dispNnClose;
       file_stream >> dispNtClose >> dispNnClose;
+      if (!file_stream) {
+        throw std::runtime_error(
+            "Failed to read time steps and node numbers from close motion file '"
+            + close_motion_file_path + "'.");
+      }
       // std::cout << "dispNtClose: " << dispNtClose << std::endl;
       // std::cout << "dispNnClose: " << dispNnClose << std::endl;
 
@@ -680,6 +704,14 @@ void uris_read_msh(Simulation* simulation) {
         for (int j = 0; j < dispNnClose; j++) {
           for (int i = 0; i < nsd; i++) {
             file_stream >> dispClose(i,j,k);
+            if (!file_stream) {
+              throw std::runtime_error(
+                  "Failed to read displacement (time=" + std::to_string(k)
+                  + ", node=" + std::to_string(j)
+                  + ", component=" + std::to_string(i)
+                  + ") from open motion file '"
+                  + close_motion_file_path + "'.");
+            }
           }
         }
       }
@@ -702,8 +734,7 @@ void uris_read_msh(Simulation* simulation) {
         }
 
         // Move data for open
-        Array3<double> tmpDxOpen(nsd, uris_obj.tnNo, dispNtOpen);
-        tmpDxOpen = uris_obj.DxOpen;
+        auto tmpDxOpen = uris_obj.DxOpen;
         uris_obj.DxOpen.resize(nsd, a, dispNtOpen);
         for (int i = 0; i < dispNtOpen; i++) {
           for (int j = 0; j < uris_obj.tnNo; j++) {
@@ -713,8 +744,7 @@ void uris_read_msh(Simulation* simulation) {
           }
         }
         // Move data for close
-        Array3<double> tmpDxClose(nsd, uris_obj.tnNo, dispNtClose);
-        tmpDxClose = uris_obj.DxClose;
+        auto tmpDxClose = uris_obj.DxClose;
         uris_obj.DxClose.resize(nsd, a, dispNtClose);
         for (int i = 0; i < dispNtClose; i++) {
           for (int j = 0; j < uris_obj.tnNo; j++) {

--- a/Code/Source/solver/uris.cpp
+++ b/Code/Source/solver/uris.cpp
@@ -1402,7 +1402,7 @@ void uris_interp_valve_velocity(const urisType& uris_obj, const Vector<double>& 
 
 /// @brief Evaluate total Brinkman factor and weighted valve velocity at element quadrature points.
 void eval_uris_ris_factors_quadrature(const ComMod& com_mod, const mshType& lM, const fsType& fs, 
-  const int e, Vector<double>& ris_factor_total_el, Array<double>& ris_valve_vel_total_el) {
+  const int e, Vector<double>& ris_factor_total_el, Array<double>& ris_valve_vel_factor_total_el) {
   #define n_dbg_eval_uris_ris_factors_quadrature
   #ifdef dbg_eval_uris_ris_factors_quadrature
     DebugMsg dmsg(__func__, 0);
@@ -1413,8 +1413,8 @@ void eval_uris_ris_factors_quadrature(const ComMod& com_mod, const mshType& lM, 
   const int nUris = com_mod.nUris;
   ris_factor_total_el.resize(fs.nG);
   ris_factor_total_el = 0.0;
-  ris_valve_vel_total_el.resize(com_mod.nsd, fs.nG);
-  ris_valve_vel_total_el = 0.0;
+  ris_valve_vel_factor_total_el.resize(com_mod.nsd, fs.nG);
+  ris_valve_vel_factor_total_el = 0.0;
 
   if (!com_mod.urisActFlag) {
     return;
@@ -1474,7 +1474,7 @@ void eval_uris_ris_factors_quadrature(const ComMod& com_mod, const mshType& lM, 
       ris_factor_total_el(g) += com_mod.uris[iUris].resistance * delta_eps;
 
       if (com_mod.uris[iUris].include_uris_velocity) {
-        ris_valve_vel_total_el.rcol(g) = ris_valve_vel_total_el.rcol(g) 
+        ris_valve_vel_factor_total_el.rcol(g) = ris_valve_vel_factor_total_el.rcol(g) 
           + com_mod.uris[iUris].resistance * delta_eps*valve_velocity.rcol(iUris);
       }
     } // iUris: loop

--- a/Code/Source/solver/uris.cpp
+++ b/Code/Source/solver/uris.cpp
@@ -1402,7 +1402,7 @@ void uris_interp_valve_velocity(const urisType& uris_obj, const Vector<double>& 
 
 /// @brief Evaluate total Brinkman factor and weighted valve velocity at element quadrature points.
 void eval_uris_ris_factors_quadrature(const ComMod& com_mod, const mshType& lM, const fsType& fs, 
-  const int e, Vector<double>& ris_factor_total_el, Array<double>& ris_valve_vel_factor_total_el) {
+  const int e, Vector<double>& uris_factor_total_el, Array<double>& uris_valve_vel_term_total_el) {
   #define n_dbg_eval_uris_ris_factors_quadrature
   #ifdef dbg_eval_uris_ris_factors_quadrature
     DebugMsg dmsg(__func__, 0);
@@ -1411,10 +1411,10 @@ void eval_uris_ris_factors_quadrature(const ComMod& com_mod, const mshType& lM, 
   #endif
 
   const int nUris = com_mod.nUris;
-  ris_factor_total_el.resize(fs.nG);
-  ris_factor_total_el = 0.0;
-  ris_valve_vel_factor_total_el.resize(com_mod.nsd, fs.nG);
-  ris_valve_vel_factor_total_el = 0.0;
+  uris_factor_total_el.resize(fs.nG);
+  uris_factor_total_el = 0.0;
+  uris_valve_vel_term_total_el.resize(com_mod.nsd, fs.nG);
+  uris_valve_vel_term_total_el = 0.0;
 
   if (!com_mod.urisActFlag) {
     return;
@@ -1471,10 +1471,10 @@ void eval_uris_ris_factors_quadrature(const ComMod& com_mod, const mshType& lM, 
       if (dist_srf(iUris) < sdf_deps && sdf_deps > 0.0) {
         delta_eps = (1 + cos(consts::pi*dist_srf(iUris)/sdf_deps))/(2*sdf_deps*sdf_deps);
       }
-      ris_factor_total_el(g) += com_mod.uris[iUris].resistance * delta_eps;
+      uris_factor_total_el(g) += com_mod.uris[iUris].resistance * delta_eps;
 
       if (com_mod.uris[iUris].include_uris_velocity) {
-        ris_valve_vel_factor_total_el.rcol(g) = ris_valve_vel_factor_total_el.rcol(g) 
+        uris_valve_vel_term_total_el.rcol(g) = uris_valve_vel_term_total_el.rcol(g) 
           + com_mod.uris[iUris].resistance * delta_eps*valve_velocity.rcol(iUris);
       }
     } // iUris: loop

--- a/Code/Source/solver/uris.cpp
+++ b/Code/Source/solver/uris.cpp
@@ -1348,11 +1348,11 @@ void uris_interp_valve_velocity(const urisType& uris_obj, const Vector<double>& 
   E2 = lX.rcol(2) - lX.rcol(0);
   v = xp_plane - lX.rcol(0);
 
-  auto g11 = utils::norm(E1, E1);
-  auto g12 = utils::norm(E1, E2); 
-  auto g22 = utils::norm(E2, E2);
-  auto b1 = utils::norm(v, E1);
-  auto b2 = utils::norm(v, E2);
+  auto g11 = E1 * E1;
+  auto g12 = E1 * E2; 
+  auto g22 = E2 * E2;
+  auto b1 = v * E1;
+  auto b2 = v * E2;
   double det = g11 * g22 - g12 * g12;
 
   double xi = (g22 * b1 - g12 * b2) / det;

--- a/Code/Source/solver/uris.h
+++ b/Code/Source/solver/uris.h
@@ -46,8 +46,12 @@ double uris_compute_sdf_sign(const urisType& uris_obj, const Vector<double>& xp,
 
 void uris_build_fluid_node_mask(ComMod& com_mod);
 
-void uris_compute_ris_factor(const ComMod& com_mod, const mshType& lM, const fsType& fs, const int e, 
-  Vector<double>& ris_factor_total_el);
+void uris_interp_valve_velocity(const urisType& uris_obj, const Vector<double>& xp, const int nsd, 
+                                const int jM, const int Ec, const double dotP, 
+                                const Vector<double>& unitNormal, Vector<double>& interp_valve_vel);
+
+void eval_uris_ris_factors_quadrature(const ComMod& com_mod, const mshType& lM, const fsType& fs, const int e, 
+  Vector<double>& ris_factor_total_el, Array<double>& ris_valve_vel_total_el);
 
 }
 

--- a/Code/Source/solver/uris.h
+++ b/Code/Source/solver/uris.h
@@ -51,7 +51,7 @@ void uris_interp_valve_velocity(const urisType& uris_obj, const Vector<double>& 
                                 const Vector<double>& unitNormal, Vector<double>& interp_valve_vel);
 
 void eval_uris_ris_factors_quadrature(const ComMod& com_mod, const mshType& lM, const fsType& fs, const int e, 
-  Vector<double>& ris_factor_total_el, Array<double>& ris_valve_vel_total_el);
+  Vector<double>& uris_factor_total_el, Array<double>& uris_valve_vel_term_total_el);
 
 }
 

--- a/Code/Source/solver/vtk_xml.cpp
+++ b/Code/Source/solver/vtk_xml.cpp
@@ -1006,7 +1006,7 @@ void write_vtus(Simulation* simulation, const SolutionStates& solutions, const b
     nOut = nOut + com_mod.nUris;
     outDof = outDof + com_mod.nUris;
     for (int iUris = 0; iUris < com_mod.nUris; iUris++) {
-      if (com_mod.uris[iUris].include_RIS_velocity) {
+      if (com_mod.uris[iUris].include_uris_velocity) {
         nOut = nOut + 1;
         outDof = outDof + nsd;
       }
@@ -1367,7 +1367,7 @@ void write_vtus(Simulation* simulation, const SolutionStates& solutions, const b
       }
 
       for (int iUris = 0; iUris < com_mod.nUris; iUris++) {
-        if (com_mod.uris[iUris].include_RIS_velocity) {
+        if (com_mod.uris[iUris].include_uris_velocity) {
           cOut = cOut + 1;
           int is = outS[cOut];
           int ie = is + nsd - 1;

--- a/Code/Source/solver/vtk_xml.cpp
+++ b/Code/Source/solver/vtk_xml.cpp
@@ -1005,6 +1005,12 @@ void write_vtus(Simulation* simulation, const SolutionStates& solutions, const b
   if (com_mod.urisFlag) {
     nOut = nOut + com_mod.nUris;
     outDof = outDof + com_mod.nUris;
+    for (int iUris = 0; iUris < com_mod.nUris; iUris++) {
+      if (com_mod.uris[iUris].include_RIS_velocity) {
+        nOut = nOut + 1;
+        outDof = outDof + nsd;
+      }
+    }
   }
 
   std::vector<std::string> outNames(nOut); 
@@ -1349,7 +1355,6 @@ void write_vtus(Simulation* simulation, const SolutionStates& solutions, const b
     if (com_mod.urisFlag) {
       for (int iUris = 0; iUris < com_mod.nUris; iUris++) {
         cOut = cOut + 1;
-        // std::cout << "uris cOut:" << cOut << std::endl;
         int is = outS[cOut];
         int ie = is;
         outS[cOut+1] = ie + 1;
@@ -1359,8 +1364,25 @@ void write_vtus(Simulation* simulation, const SolutionStates& solutions, const b
           int Ac = msh.gN(a);
           d[iM].x(is,a) = static_cast<double>(com_mod.uris[iUris].sdf(Ac));
         }
-      } 
-    } 
+      }
+
+      for (int iUris = 0; iUris < com_mod.nUris; iUris++) {
+        if (com_mod.uris[iUris].include_RIS_velocity) {
+          cOut = cOut + 1;
+          int is = outS[cOut];
+          int ie = is + nsd - 1;
+          outS[cOut+1] = ie + 1;
+          outNames[cOut] = "URIS_VEL_" + com_mod.uris[iUris].name;
+          for (int a = 0; a < msh.nNo; a++) {
+            int Ac = msh.gN(a);
+            for (int b = is; b <= ie; b++) {
+              d[iM].x(b,a) = static_cast<double>(com_mod.uris[iUris].valve_velocity_fluid(b-is, Ac));
+            }
+          }
+        }
+      }
+
+    }
 
   } // iM for loop 
 

--- a/tests/cases/uris/pipe_uris_cfd/README.md
+++ b/tests/cases/uris/pipe_uris_cfd/README.md
@@ -13,7 +13,22 @@ The model parameters are specified in the `Add_URIS_mesh` sub-section
   </Add_URIS_face>
   <Mesh_scale_factor> 1.0 </Mesh_scale_factor>
   <Thickness> 0.2 </Thickness>
+  <Closed_thickness> 0.2 </Closed_thickness>
   <Resistance> 1.0e5 </Resistance>
+  <Invert_normal> false </Invert_normal>
+  <Include_URIS_velocity> true </Include_URIS_velocity>
   <Positive_flow_normal_file_path> meshes/normal.dat </Positive_flow_normal_file_path>
 </Add_URIS_mesh>
 ```
+
+In this test, the valve velocity $u_{\Gamma_i}$ associated with the prescribed valve motion is included in the URIS forcing term by setting `Include_URIS_velocity` as `true`,
+
+$$
+f_{\mathrm{URIS}} = \sum_{i=1}^{n} \left( u - u_{\Gamma_i} \right) \text{ .}
+$$
+
+The valve velocity $u_{\Gamma_i}$ is computed using finite differences based on the input valve motion data. If the input motion is sampled with relatively large time steps, the resulting velocity may be noisy or inaccurate. To improve the temporal resolution of the prescribed motion, the valve trajectory can be interpolated using the utility provided in
+
+`svMultiPhysics/utilities/interpolate_uris_valve_velocity/`
+
+This script generates a refined valve motion dataset with additional intermediate frames, leading to a smoother and more accurate estimate of $u_{\Gamma_i}$.

--- a/tests/cases/uris/pipe_uris_cfd/result_003.vtu
+++ b/tests/cases/uris/pipe_uris_cfd/result_003.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98385819e19b1e0244f83f4a8ccccba7dc7e1d94a74eb3e406ddedb70086b8c6
+size 1547683

--- a/tests/cases/uris/pipe_uris_cfd/result_005.vtu
+++ b/tests/cases/uris/pipe_uris_cfd/result_005.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1908c879949ea025d53905e92bec5807d39a26012e716d1180ba33f61b0bea31
-size 1460399

--- a/tests/cases/uris/pipe_uris_cfd/solver.xml
+++ b/tests/cases/uris/pipe_uris_cfd/solver.xml
@@ -5,7 +5,7 @@
 
   <Continue_previous_simulation> false </Continue_previous_simulation>
   <Number_of_spatial_dimensions> 3 </Number_of_spatial_dimensions> 
-  <Number_of_time_steps> 5 </Number_of_time_steps> 
+  <Number_of_time_steps> 3 </Number_of_time_steps> 
   <Time_step_size> 0.001 </Time_step_size> 
   <Spectral_radius_of_infinite_time_step> 0.50 </Spectral_radius_of_infinite_time_step> 
   <Searched_file_name_to_trigger_stop> STOP_SIM </Searched_file_name_to_trigger_stop> 
@@ -60,6 +60,7 @@
   <Closed_thickness> 0.2 </Closed_thickness>
   <Resistance> 1.0e5 </Resistance>
   <Invert_normal> false </Invert_normal>
+  <Include_URIS_velocity> true </Include_URIS_velocity>
   <Positive_flow_normal_file_path> meshes/normal.dat </Positive_flow_normal_file_path>
 </Add_URIS_mesh>
 
@@ -84,6 +85,7 @@
   <Closed_thickness> 0.2 </Closed_thickness>
   <Resistance> 1.0e5 </Resistance>
   <Invert_normal> false </Invert_normal>
+  <Include_URIS_velocity> true </Include_URIS_velocity>
   <Positive_flow_normal_file_path> meshes/normal.dat </Positive_flow_normal_file_path>
 </Add_URIS_mesh>
 

--- a/tests/test_uris.py
+++ b/tests/test_uris.py
@@ -10,7 +10,7 @@ fields_cfd = ["Velocity", "Pressure", "Traction", "WSS", "Vorticity", "Divergenc
 
 def test_pipe_uris_cfd(n_proc):
     test_folder = "pipe_uris_cfd"
-    t_max = 5
+    t_max = 3
     run_with_reference(base_folder, test_folder, fields_cfd, n_proc, t_max)
 
 fields_fsi = ["Displacement", "Pressure", "Velocity"]

--- a/utilities/README.md
+++ b/utilities/README.md
@@ -4,3 +4,4 @@ The utilities directory contains pre- and post-processing scripts that can be us
 
 The following scripts are provided:
 - fourier_coefficients: generation of fourier coefficients after providing temporal flow data 
+- URIS valve motion interpolation: Generate interpolated prescribed valve motion for selected time intervals with a user-specified number of output frames to improve valve velocity estimation

--- a/utilities/README.md
+++ b/utilities/README.md
@@ -3,5 +3,8 @@
 The utilities directory contains pre- and post-processing scripts that can be useful for svMultiphysics. 
 
 The following scripts are provided:
-- fourier_coefficients: generation of fourier coefficients after providing temporal flow data 
-- URIS valve motion interpolation: Generate interpolated prescribed valve motion for selected time intervals with a user-specified number of output frames to improve valve velocity estimation
+- `fourier_coefficients`: generation of fourier coefficients after providing temporal flow data.
+- `fiber_generation`: generate myocardial fiber orientations for biventricular heart models using the Bayer et al. (2012) and Doste et al. (2018) rule-based methods.
+- `generate_boundary_condition_data`: generate svMultiPhysics boundary condition inputs, including transient load profiles and spatially varying Robin boundary condition fields defined from user-specified analytical functions.
+- `generate_cap_surface`: generate cap surfaces for open VTP surface meshes by filling holes, recomputing normals, and saving both the capped mesh and the extracted cap as separate VTP files.
+- `interpolate_uris_valve_velocity`: generate interpolated prescribed valve motion for selected time intervals with a user-specified number of output frames to improve valve velocity estimation.

--- a/utilities/interpolate_uris_valve_velocity/README.md
+++ b/utilities/interpolate_uris_valve_velocity/README.md
@@ -1,0 +1,147 @@
+# Interpolate URIS Valve Velocity
+
+This utility generates an interpolated valve motion dataset from an existing valve motion `.dat` file. The primary use case is to increase the temporal resolution of prescribed valve motion before computing the valve velocity used in the URIS forcing term.
+
+## Background
+
+The URIS formulation includes the prescribed valve velocity $u_{\Gamma_i}$,
+
+$$
+f_{\mathrm{URIS}} = \sum_{i=1}^{n} \left( u - u_{\Gamma_i} \right) \text{ .}
+$$
+
+The valve velocity is computed using finite differences of the prescribed valve motion. If the input motion is sampled with relatively large time steps, the resulting velocity can be noisy and may introduce interpolation errors. This utility creates additional intermediate frames to obtain a smoother estimate of the valve velocity.
+
+## Input Format
+
+The script expects a valve motion `.dat` file with the following format:
+
+```text
+<n_steps> <n_nodes>
+x y z
+x y z
+...
+```
+
+where:
+
+* `n_steps` is the number of time frames.
+* `n_nodes` is the number of mesh nodes.
+* Coordinates are stored in time-major order:
+
+  * all nodes for frame 0,
+  * followed by all nodes for frame 1,
+  * etc.
+
+For example:
+
+```text
+40 200
+0.123 1.234 2.345
+0.456 1.567 2.678
+...
+```
+
+## Configuration
+
+The script is configured through the `REQUESTS` list.
+
+Each segment is specified as:
+
+```python
+Segment(start_step, end_step, num_output_frames, two_frame=False)
+```
+
+Parameters:
+
+* `start_step`: first frame of the segment.
+* `end_step`: last frame of the segment.
+* `num_output_frames`: number of output frames to generate, including both endpoints.
+* `two_frame`:
+
+  * `False`: interpolate using the original motion trajectory.
+  * `True`: linearly blend between the start and end frames only.
+
+Example:
+
+```python
+REQUESTS = [
+    Segment(290, 329, 40),
+]
+```
+
+This generates 40 frames between timesteps 290 and 329, including both endpoints.
+
+## Interpolation Methods
+
+Two interpolation methods are available:
+
+```python
+METHOD = "linear"
+```
+
+or
+
+```python
+METHOD = "quadratic"
+```
+
+### Linear
+
+Piecewise-linear interpolation between neighboring frames.
+
+### Quadratic
+
+Local quadratic interpolation using three neighboring frames. Near boundaries, the method automatically falls back to linear interpolation.
+
+## Example
+
+Input file:
+
+```text
+NCC_motion.dat
+```
+
+Configuration:
+
+```python
+leaflet_name = "NCC"
+state = "open"
+
+METHOD = "linear"
+
+REQUESTS = [
+    Segment(290, 329, 40),
+]
+```
+
+Run:
+
+```bash
+python interp_motion_data.py
+```
+
+Output:
+
+```text
+NCC_motion_interp.dat
+```
+
+## Multi-Segment Example
+
+```python
+REQUESTS = [
+    Segment(329, 420, 10, two_frame=True),
+    Segment(420, 450, 10, two_frame=True),
+    Segment(450, 290, 22),
+]
+```
+
+The generated segments are concatenated into a single output motion file. If consecutive segments share an endpoint, duplicate frames are automatically removed.
+
+## Notes
+
+* All output segments include both endpoints.
+* The output file preserves the original mesh topology.
+* Only nodal coordinates are interpolated.
+* The script is intended as a preprocessing utility for generating smoother valve velocity data used by URIS simulations.

--- a/utilities/interpolate_uris_valve_velocity/interp_motion_data.py
+++ b/utilities/interpolate_uris_valve_velocity/interp_motion_data.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Interpolate selected frame ranges from a valve-motion .dat file.
+
+The input .dat file is expected to have this format:
+
+    <n_steps> <n_nodes>
+    x y z
+    x y z
+    ...
+
+Coordinate rows are time-major: all nodes for frame 0, then all nodes for
+frame 1, and so on.
+
+By default, edit the values in ``DEFAULT_CONFIG`` and run:
+
+    python interp_motion_data_clean.py
+
+You can also override the input/output paths from the command line:
+
+    python interp_motion_data.py --input NCC_motion.dat --output NCC_motion_interp.dat
+
+Notes
+-----
+* Each segment request is ``(start_frame, end_frame, num_samples)``.
+* ``num_samples`` includes both endpoints.
+* If ``start_frame <= end_frame``, samples are taken along the original time
+  sequence using the selected interpolation method.
+* If ``start_frame > end_frame``, this linearly blends directly between the two keyframes.
+  It does *not* wrap through the end of the sequence.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+COMMENT_PREFIXES = ("#", "//", "%", ";")
+VALID_METHODS = {"linear", "quadratic"}
+
+
+@dataclass(frozen=True)
+class SegmentRequest:
+    """Request ``num_samples`` frames between two source frames, inclusive."""
+
+    start_frame: int
+    end_frame: int
+    num_samples: int
+    use_two_frame_blend: bool = False
+
+
+@dataclass(frozen=True)
+class InterpolationConfig:
+    """User-editable interpolation settings."""
+
+    input_dat: Path
+    output_dat: Path
+    method: str = "linear"
+    requests: tuple[SegmentRequest, ...] = ()
+    join_touching_endpoints: bool = True
+    precision: int = 6
+
+
+# ---------------------------------------------------------------------------
+# Default settings
+# ---------------------------------------------------------------------------
+# Edit this block for motion interpolation. Command-line arguments can override the
+# input/output paths and interpolation method when needed.
+DEFAULT_CONFIG = InterpolationConfig(
+    input_dat=Path("NCC_motion.dat"),
+    output_dat=Path("NCC_motion_interp.dat"),
+    method="linear",
+    requests=(
+        SegmentRequest(start_frame=290, end_frame=329, num_samples=40),
+    ),
+    join_touching_endpoints=True,
+    precision=6,
+)
+
+# Example close-cycle configuration. Copy into DEFAULT_CONFIG.requests when
+# needed instead of keeping many commented-out blocks throughout the script.
+EXAMPLE_CLOSE_REQUESTS = (
+    SegmentRequest(329, 420, 10, use_two_frame_blend=True),
+    SegmentRequest(420, 450, 10, use_two_frame_blend=True),
+    SegmentRequest(450, 290, 22, use_two_frame_blend=False),
+)
+
+
+# ---------------------------------------------------------------------------
+# File I/O
+# ---------------------------------------------------------------------------
+def read_dat(dat_path: str | Path) -> np.ndarray:
+    """Read a motion .dat file as an array with shape ``(n_steps, n_nodes, 3)``."""
+
+    dat_path = Path(dat_path)
+    with dat_path.open("r", encoding="utf-8") as handle:
+        header = _read_header(handle)
+        n_steps, n_nodes = _parse_header(header)
+        coords = _read_coordinates(handle)
+
+    expected_rows = n_steps * n_nodes
+    if coords.shape[0] != expected_rows:
+        raise ValueError(
+            f"Data length mismatch in {dat_path}: header says "
+            f"{n_steps} * {n_nodes} = {expected_rows} coordinate rows, "
+            f"but found {coords.shape[0]}."
+        )
+
+    return coords.reshape(n_steps, n_nodes, 3)
+
+
+def _read_header(handle) -> str:
+    """Return the first non-empty, non-comment line from an open file handle."""
+
+    for raw_line in handle:
+        line = raw_line.strip()
+        if line and not line.startswith(COMMENT_PREFIXES):
+            return line
+    raise ValueError("Input file is empty or missing a '<n_steps> <n_nodes>' header.")
+
+
+def _parse_header(header: str) -> tuple[int, int]:
+    """Parse the ``<n_steps> <n_nodes>`` header line."""
+
+    parts = header.replace(",", " ").split()
+    if len(parts) < 2:
+        raise ValueError("Header must contain '<n_steps> <n_nodes>'.")
+
+    try:
+        n_steps = int(float(parts[0]))
+        n_nodes = int(float(parts[1]))
+    except ValueError as exc:
+        raise ValueError(f"Could not parse .dat header: {header!r}") from exc
+
+    if n_steps <= 0 or n_nodes <= 0:
+        raise ValueError("Header values n_steps and n_nodes must be positive.")
+
+    return n_steps, n_nodes
+
+
+def _read_coordinates(handle) -> np.ndarray:
+    """Read all coordinate rows from an open .dat file handle."""
+
+    rows: list[list[float]] = []
+    for line_number, raw_line in enumerate(handle, start=2):
+        line = raw_line.strip()
+        if not line or line.startswith(COMMENT_PREFIXES):
+            continue
+
+        parts = line.replace(",", " ").split()
+        if len(parts) != 3:
+            raise ValueError(
+                f"Expected three coordinate values on line {line_number}, got: {line!r}"
+            )
+
+        try:
+            rows.append([float(value) for value in parts])
+        except ValueError as exc:
+            raise ValueError(
+                f"Could not parse coordinate values on line {line_number}: {line!r}"
+            ) from exc
+
+    return np.asarray(rows, dtype=np.float64)
+
+
+def write_dat(
+    out_path: str | Path,
+    frames: Sequence[np.ndarray],
+    n_nodes: int,
+    precision: int = 6,
+) -> None:
+    """Write interpolated frames to a motion .dat file."""
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fmt = f"%.{precision}f %.{precision}f %.{precision}f"
+    with out_path.open("w", encoding="utf-8") as handle:
+        handle.write(f"{len(frames)} {n_nodes}\n")
+        for frame in frames:
+            np.savetxt(handle, frame, fmt=fmt)
+
+
+# ---------------------------------------------------------------------------
+# Interpolation
+# ---------------------------------------------------------------------------
+def interpolate_frames(coords: np.ndarray, config: InterpolationConfig) -> list[np.ndarray]:
+    """Build all requested interpolated frames from ``coords``."""
+
+    method = config.method.lower().strip()
+    if method not in VALID_METHODS:
+        raise ValueError(f"method must be one of {sorted(VALID_METHODS)}, got {config.method!r}.")
+
+    if not config.requests:
+        raise ValueError("At least one SegmentRequest is required.")
+
+    frames_out: list[np.ndarray] = []
+    previous_end: int | None = None
+
+    for request in config.requests:
+        _validate_request(request, n_steps=coords.shape[0])
+        segment = sample_segment(coords, request, method)
+
+        if (
+            config.join_touching_endpoints
+            and previous_end is not None
+            and request.start_frame == previous_end
+        ):
+            segment = segment[1:]
+
+        frames_out.extend(segment)
+        previous_end = request.end_frame
+
+    if not frames_out:
+        raise RuntimeError("No frames produced. Check the segment requests.")
+
+    return frames_out
+
+
+def _validate_request(request: SegmentRequest, n_steps: int) -> None:
+    """Validate a segment request against the source sequence length."""
+
+    if not 0 <= request.start_frame < n_steps:
+        raise ValueError(f"start_frame must be in [0, {n_steps - 1}], got {request.start_frame}.")
+    if not 0 <= request.end_frame < n_steps:
+        raise ValueError(f"end_frame must be in [0, {n_steps - 1}], got {request.end_frame}.")
+    if request.num_samples < 2:
+        raise ValueError("num_samples must be at least 2 because endpoints are included.")
+
+
+def sample_segment(
+    coords: np.ndarray,
+    request: SegmentRequest,
+    method: str,
+) -> list[np.ndarray]:
+    """Sample one configured segment."""
+
+    if request.use_two_frame_blend or request.start_frame > request.end_frame:
+        return sample_two_keyframe_blend(
+            coords,
+            request.start_frame,
+            request.end_frame,
+            request.num_samples,
+        )
+
+    return sample_along_sequence(
+        coords,
+        request.start_frame,
+        request.end_frame,
+        request.num_samples,
+        method,
+    )
+
+
+def sample_along_sequence(
+    coords: np.ndarray,
+    start_frame: int,
+    end_frame: int,
+    num_samples: int,
+    method: str,
+) -> list[np.ndarray]:
+    """Sample a non-wrapping segment along the original time sequence."""
+
+    sample_times = np.linspace(float(start_frame), float(end_frame), num=num_samples)
+    return [interpolate_at_time(coords, time, method) for time in sample_times]
+
+
+def sample_two_keyframe_blend(
+    coords: np.ndarray,
+    start_frame: int,
+    end_frame: int,
+    num_samples: int,
+) -> list[np.ndarray]:
+    """Linearly blend between two keyframes, ignoring intermediate frames."""
+
+    start_coords = coords[start_frame]
+    end_coords = coords[end_frame]
+    alphas = np.linspace(0.0, 1.0, num=num_samples)
+    return [linear_blend(start_coords, end_coords, alpha) for alpha in alphas]
+
+
+def interpolate_at_time(coords: np.ndarray, time: float, method: str) -> np.ndarray:
+    """Interpolate the source sequence at a real-valued frame index."""
+
+    rounded = round(time)
+    if abs(time - rounded) < 1e-12:
+        return coords[int(rounded)]
+
+    if method == "linear":
+        return interpolate_linear_sequence(coords, time)
+    if method == "quadratic":
+        return interpolate_quadratic_sequence(coords, time)
+
+    raise ValueError(f"Unknown interpolation method: {method!r}")
+
+
+def linear_blend(start_coords: np.ndarray, end_coords: np.ndarray, alpha: float) -> np.ndarray:
+    """Linearly blend two coordinate arrays at fraction ``alpha`` in ``[0, 1]``."""
+
+    return (1.0 - alpha) * start_coords + alpha * end_coords
+
+
+def interpolate_linear_sequence(coords: np.ndarray, time: float) -> np.ndarray:
+    """Piecewise-linear interpolation along adjacent source frames."""
+
+    n_steps = coords.shape[0]
+    if time <= 0:
+        return coords[0]
+    if time >= n_steps - 1:
+        return coords[-1]
+
+    left = int(np.floor(time))
+    alpha = time - left
+    return linear_blend(coords[left], coords[left + 1], alpha)
+
+
+def interpolate_quadratic_sequence(coords: np.ndarray, time: float) -> np.ndarray:
+    """Local quadratic interpolation through frames ``t-1``, ``t``, and ``t+1``.
+
+    The function falls back to linear interpolation at the sequence boundaries,
+    where a three-frame stencil is unavailable.
+    """
+
+    n_steps = coords.shape[0]
+    if time <= 0:
+        return coords[0]
+    if time >= n_steps - 1:
+        return coords[-1]
+
+    center = int(np.floor(time))
+    alpha = time - center
+
+    if center - 1 < 0 or center + 1 >= n_steps:
+        return interpolate_linear_sequence(coords, time)
+
+    previous_frame = coords[center - 1]
+    current_frame = coords[center]
+    next_frame = coords[center + 1]
+
+    # Lagrange basis evaluated at alpha for nodes -1, 0, +1.
+    weight_previous = alpha * (alpha - 1.0) / 2.0
+    weight_current = 1.0 - alpha * alpha
+    weight_next = alpha * (alpha + 1.0) / 2.0
+
+    return (
+        weight_previous * previous_frame
+        + weight_current * current_frame
+        + weight_next * next_frame
+    )
+
+
+# ---------------------------------------------------------------------------
+# Command-line interface
+# ---------------------------------------------------------------------------
+def parse_args() -> argparse.Namespace:
+    """Parse optional command-line overrides."""
+
+    parser = argparse.ArgumentParser(
+        description="Interpolate selected frame ranges from a valve-motion .dat file."
+    )
+    parser.add_argument("--input", type=Path, help="Input .dat file.")
+    parser.add_argument("--output", type=Path, help="Output .dat file.")
+    parser.add_argument(
+        "--method",
+        choices=sorted(VALID_METHODS),
+        help="Interpolation method for along-sequence segments.",
+    )
+    parser.add_argument(
+        "--precision",
+        type=int,
+        help="Number of decimal places written to the output file.",
+    )
+    return parser.parse_args()
+
+
+def config_from_args(args: argparse.Namespace) -> InterpolationConfig:
+    """Apply command-line overrides to ``DEFAULT_CONFIG``."""
+
+    return InterpolationConfig(
+        input_dat=args.input or DEFAULT_CONFIG.input_dat,
+        output_dat=args.output or DEFAULT_CONFIG.output_dat,
+        method=args.method or DEFAULT_CONFIG.method,
+        requests=DEFAULT_CONFIG.requests,
+        join_touching_endpoints=DEFAULT_CONFIG.join_touching_endpoints,
+        precision=args.precision if args.precision is not None else DEFAULT_CONFIG.precision,
+    )
+
+
+def main() -> None:
+    """Read the input file, interpolate requested segments, and write the output."""
+
+    config = config_from_args(parse_args())
+    coords = read_dat(config.input_dat)
+    frames = interpolate_frames(coords, config)
+    write_dat(config.output_dat, frames, n_nodes=coords.shape[1], precision=config.precision)
+    print(f"Wrote {len(frames)} frames to {config.output_dat}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Resolves https://github.com/SimVascular/svMultiPhysics/issues/558

## Release Notes 
* Computed valve velocity $u_{\Gamma}$ from prescribed valve motion using finite differences
* Included valve velocity $u_{\Gamma}$ in the URIS force term $f_{RIS} = R {\delta} (u - u_{\Gamma})$
* Added an optional input argument `Include_URIS_velocity` to enable inclusion of valve velocity. The default is `false`

## Testing
* Updated the URIS CFD test case reference results with valve velocity enabled. All tests passed

## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
