### PR TITLE
Add geometric filtering for CEP stimuli

### DIFF
--- a/Code/Source/solver/CepMod.cpp
+++ b/Code/Source/solver/CepMod.cpp
@@ -134,15 +134,9 @@ void stimType::SpatialBounds::distribute(const CmMod& cm_mod, const cmType& cm)
 
 double stimType::operator()(const double time, const Vector<double>& x) const
 {
-  if (utils::is_zero(amplitude)) {
-    return 0.0;
-  }
-
-  if (!is_active(time)) {
-    return 0.0;
-  }
-
-  if (!spatial_bounds.contains(x)) {
+  if (utils::is_zero(amplitude) ||
+      !is_active(time) ||
+      !spatial_bounds.contains(x)) {
     return 0.0;
   }
 

--- a/Code/Source/solver/CepMod.cpp
+++ b/Code/Source/solver/CepMod.cpp
@@ -35,9 +35,9 @@ bool stimType::is_active(const double time) const
 {
   const double eps = std::numeric_limits<double>::epsilon();
 
-  const int icl = static_cast<int>(fmax(floor(time / CL), 0.0));
-  const double Ts_cycle = Ts + static_cast<double>(icl) * CL;
-  const double Te_cycle = Ts_cycle + Td;
+  const int icl = static_cast<int>(fmax(floor(time / cycle_length_), 0.0));
+  const double Ts_cycle = start_time_ + static_cast<double>(icl) * cycle_length_;
+  const double Te_cycle = Ts_cycle + duration_;
 
   return Ts_cycle - eps <= time && time <= Te_cycle + eps;
 }
@@ -144,7 +144,7 @@ void SpatialBounds::distribute(const CmMod& cm_mod, const cmType& cm)
 
 double stimType::operator()(const double time, const Vector<double>& x) const
 {
-  if (utils::is_zero(A)) {
+  if (utils::is_zero(amplitude_)) {
     return 0.0;
   }
 
@@ -156,26 +156,26 @@ double stimType::operator()(const double time, const Vector<double>& x) const
     return 0.0;
   }
 
-  return A;
+  return amplitude_;
 }
 
 void stimType::distribute(const CmMod& cm_mod, const cmType& cm)
 {
-  cm.bcast(cm_mod, &Ts);
-  cm.bcast(cm_mod, &Td);
-  cm.bcast(cm_mod, &CL);
-  cm.bcast(cm_mod, &A);
+  cm.bcast(cm_mod, &start_time_);
+  cm.bcast(cm_mod, &duration_);
+  cm.bcast(cm_mod, &cycle_length_);
+  cm.bcast(cm_mod, &amplitude_);
   spatial_bounds_.distribute(cm_mod, cm);
 }
 
 void stimType::read_parameters(const StimulusParameters& params, const int nsd, const double default_cycle_length)
 {
-  A = params.amplitude.value();
+  amplitude_ = params.amplitude.value();
 
-  if (!utils::is_zero(A)) {
-    Ts = params.start_time.value();
-    Td = params.duration.value();
-    CL = params.cycle_length.defined() ? params.cycle_length.value() : default_cycle_length;
+  if (!utils::is_zero(amplitude_)) {
+    start_time_ = params.start_time.value();
+    duration_ = params.duration.value();
+    cycle_length_ = params.cycle_length.defined() ? params.cycle_length.value() : default_cycle_length;
   }
 
   const auto& spatial_bounds_params = params.spatial_bounds;
@@ -199,9 +199,9 @@ void stimType::read_parameters(const StimulusParameters& params, const int nsd, 
           SVMP_HERE, "Stimulus box Minimum and Maximum must have the same coordinate dimension.");
     }
 
-    if (box_min_vals.size() < static_cast<std::size_t>(nsd)) {
+    if (box_min_vals.size() != static_cast<std::size_t>(nsd)) {
       svmp::raise<svmp::ParseException>(
-          SVMP_HERE, "Stimulus box dimension is smaller than the simulation spatial dimension.");
+          SVMP_HERE, "Stimulus box coordinate dimension must match the simulation spatial dimension.");
     }
 
     Vector<double> box_min(box_min_vals.size());
@@ -234,9 +234,9 @@ void stimType::read_parameters(const StimulusParameters& params, const int nsd, 
     const auto& sphere_center_vals = sphere_params.center.value();
     const double sphere_radius_val = sphere_params.radius.value();
 
-    if (sphere_center_vals.size() < static_cast<std::size_t>(nsd)) {
+    if (sphere_center_vals.size() != static_cast<std::size_t>(nsd)) {
       svmp::raise<svmp::ParseException>(
-          SVMP_HERE, "Stimulus sphere center dimension is smaller than the simulation spatial dimension.");
+          SVMP_HERE, "Stimulus sphere center coordinate dimension must match the simulation spatial dimension.");
     }
 
     if (sphere_radius_val < 0.0) {

--- a/Code/Source/solver/CepMod.cpp
+++ b/Code/Source/solver/CepMod.cpp
@@ -35,36 +35,41 @@ bool stimType::is_active(const double time) const
 {
   const double eps = std::numeric_limits<double>::epsilon();
 
-  const int icl = static_cast<int>(fmax(floor(time / cycle_length_), 0.0));
-  const double Ts_cycle = start_time_ + static_cast<double>(icl) * cycle_length_;
-  const double Te_cycle = Ts_cycle + duration_;
-
-  return Ts_cycle - eps <= time && time <= Te_cycle + eps;
+  const double time_relative = std::fmod(time, cycle_length);
+  return start_time - eps <= time_relative && time_relative <= start_time + duration + eps;
 }
 
-void SpatialBounds::set_box(const Vector<double>& min, const Vector<double>& max)
+void stimType::SpatialBounds::set_box(const Vector<double>& min, const Vector<double>& max)
 {
-  box_min_ = min;
-  box_max_ = max;
-  region_type_ = (region_type_ == RegionType::sphere) ? RegionType::both : RegionType::box;
+  svmp::throw_if<svmp::FE::InvalidArgumentException>(
+      min.size() == 0, "Stimulus box bounds must have at least one coordinate.");
+  svmp::throw_if<svmp::FE::InvalidArgumentException>(
+      min.size() != max.size(), "Stimulus box minimum and maximum must have the same coordinate dimension.");
+  box_min = min;
+  box_max = max;
+  has_box = true;
 }
 
-void SpatialBounds::set_sphere(const Vector<double>& center, const double radius)
+void stimType::SpatialBounds::set_sphere(const Vector<double>& center, const double radius)
 {
-  sphere_center_ = center;
-  sphere_radius_ = radius;
-  region_type_ = (region_type_ == RegionType::box) ? RegionType::both : RegionType::sphere;
+  svmp::throw_if<svmp::FE::InvalidArgumentException>(
+      center.size() == 0, "Stimulus sphere center must have at least one coordinate.");
+  svmp::throw_if<svmp::FE::InvalidArgumentException>(
+      radius < 0.0, "Stimulus sphere radius must be non-negative.");
+  sphere_center = center;
+  sphere_radius = radius;
+  has_sphere = true;
 }
 
-bool SpatialBounds::inside_box(const Vector<double>& x) const
+bool stimType::SpatialBounds::inside_box(const Vector<double>& x) const
 {
-  if (x.size() != box_min_.size()) {
+  if (x.size() != box_min.size()) {
     svmp::raise<svmp::FE::InvalidArgumentException>(
-        SVMP_HERE, "Point dimension does not match stimulus box dimension.");
+        "Point dimension does not match stimulus box dimension.");
   }
 
   for (int i = 0; i < x.size(); i++) {
-    if (x(i) < box_min_(i) || x(i) > box_max_(i)) {
+    if (x[i] < box_min[i] || x[i] > box_max[i]) {
       return false;
     }
   }
@@ -72,79 +77,64 @@ bool SpatialBounds::inside_box(const Vector<double>& x) const
   return true;
 }
 
-bool SpatialBounds::inside_sphere(const Vector<double>& x) const
+bool stimType::SpatialBounds::inside_sphere(const Vector<double>& x) const
 {
-  if (x.size() != sphere_center_.size()) {
+  if (x.size() != sphere_center.size()) {
     svmp::raise<svmp::FE::InvalidArgumentException>(
-        SVMP_HERE, "Point dimension does not match stimulus sphere dimension.");
+        "Point dimension does not match stimulus sphere dimension.");
   }
 
   double distance_squared = 0.0;
 
   for (int i = 0; i < x.size(); i++) {
-    const double dx = x(i) - sphere_center_(i);
+    const double dx = x[i] - sphere_center[i];
     distance_squared += dx * dx;
   }
 
-  return distance_squared <= sphere_radius_ * sphere_radius_;
+  return distance_squared <= sphere_radius * sphere_radius;
 }
 
-bool SpatialBounds::contains(const Vector<double>& x) const
+bool stimType::SpatialBounds::contains(const Vector<double>& x) const
 {
-  switch (region_type_) {
-    case RegionType::none:   return true;
-    case RegionType::box:    return inside_box(x);
-    case RegionType::sphere: return inside_sphere(x);
-    case RegionType::both:   return inside_box(x) && inside_sphere(x);
-  }
+  if (has_box && !inside_box(x)) return false;
+  if (has_sphere && !inside_sphere(x)) return false;
   return true;
 }
 
-void SpatialBounds::distribute(const CmMod& cm_mod, const cmType& cm)
+void stimType::SpatialBounds::distribute(const CmMod& cm_mod, const cmType& cm)
 {
-  int region_type_int = static_cast<int>(region_type_);
-  cm.bcast(cm_mod, &region_type_int);
-  region_type_ = static_cast<RegionType>(region_type_int);
+  cm.bcast(cm_mod, &has_box);
+  cm.bcast(cm_mod, &has_sphere);
 
-  if (region_type_ == RegionType::box || region_type_ == RegionType::both) {
-    int box_size = box_min_.size();
+  if (has_box) {
+    int box_size = box_min.size();
     cm.bcast(cm_mod, &box_size);
 
-    if (box_size <= 0) {
-      svmp::raise<svmp::FE::InvalidArgumentException>(
-          SVMP_HERE, "Stimulus box has invalid coordinate dimension.");
-    }
-
     if (cm.slv(cm_mod)) {
-      box_min_.resize(box_size);
-      box_max_.resize(box_size);
+      box_min.resize(box_size);
+      box_max.resize(box_size);
     }
 
-    cm.bcast(cm_mod, box_min_, "SpatialBounds box_min");
-    cm.bcast(cm_mod, box_max_, "SpatialBounds box_max");
+    cm.bcast(cm_mod, box_min, "SpatialBounds box_min");
+    cm.bcast(cm_mod, box_max, "SpatialBounds box_max");
   }
 
-  if (region_type_ == RegionType::sphere || region_type_ == RegionType::both) {
-    int sphere_center_size = sphere_center_.size();
+  if (has_sphere) {
+    int sphere_center_size = sphere_center.size();
     cm.bcast(cm_mod, &sphere_center_size);
 
-    if (sphere_center_size <= 0) {
-      svmp::raise<svmp::FE::InvalidArgumentException>(
-          SVMP_HERE, "Stimulus sphere center has invalid coordinate dimension.");
-    }
-
     if (cm.slv(cm_mod)) {
-      sphere_center_.resize(sphere_center_size);
+      sphere_center.resize(sphere_center_size);
     }
 
-    cm.bcast(cm_mod, sphere_center_, "SpatialBounds sphere_center");
-    cm.bcast(cm_mod, &sphere_radius_);
+    cm.bcast(cm_mod, sphere_center, "SpatialBounds sphere_center");
+    cm.bcast(cm_mod, &sphere_radius);
   }
 }
 
 double stimType::operator()(const double time, const Vector<double>& x) const
 {
-  if (utils::is_zero(amplitude_)) {
+  if (utils::is_zero(amplitude)) {
     return 0.0;
   }
 
@@ -152,30 +142,30 @@ double stimType::operator()(const double time, const Vector<double>& x) const
     return 0.0;
   }
 
-  if (!spatial_bounds_.contains(x)) {
+  if (!spatial_bounds.contains(x)) {
     return 0.0;
   }
 
-  return amplitude_;
+  return amplitude;
 }
 
 void stimType::distribute(const CmMod& cm_mod, const cmType& cm)
 {
-  cm.bcast(cm_mod, &start_time_);
-  cm.bcast(cm_mod, &duration_);
-  cm.bcast(cm_mod, &cycle_length_);
-  cm.bcast(cm_mod, &amplitude_);
-  spatial_bounds_.distribute(cm_mod, cm);
+  cm.bcast(cm_mod, &start_time);
+  cm.bcast(cm_mod, &duration);
+  cm.bcast(cm_mod, &cycle_length);
+  cm.bcast(cm_mod, &amplitude);
+  spatial_bounds.distribute(cm_mod, cm);
 }
 
 void stimType::read_parameters(const StimulusParameters& params, const int nsd, const double default_cycle_length)
 {
-  amplitude_ = params.amplitude.value();
+  amplitude = params.amplitude.value();
 
-  if (!utils::is_zero(amplitude_)) {
-    start_time_ = params.start_time.value();
-    duration_ = params.duration.value();
-    cycle_length_ = params.cycle_length.defined() ? params.cycle_length.value() : default_cycle_length;
+  if (!utils::is_zero(amplitude)) {
+    start_time = params.start_time.value();
+    duration = params.duration.value();
+    cycle_length = params.cycle_length.defined() ? params.cycle_length.value() : default_cycle_length;
   }
 
   const auto& spatial_bounds_params = params.spatial_bounds;
@@ -187,7 +177,7 @@ void stimType::read_parameters(const StimulusParameters& params, const int nsd, 
 
   if (box_is_defined && !(box_min_defined && box_max_defined)) {
     svmp::raise<svmp::ParseException>(
-        SVMP_HERE, "Both Minimum and Maximum must be specified for a CEP stimulus box.");
+        "Both Minimum and Maximum must be specified for a CEP stimulus box.");
   }
 
   if (box_is_defined) {
@@ -196,12 +186,12 @@ void stimType::read_parameters(const StimulusParameters& params, const int nsd, 
 
     if (box_min_vals.size() != box_max_vals.size()) {
       svmp::raise<svmp::ParseException>(
-          SVMP_HERE, "Stimulus box Minimum and Maximum must have the same coordinate dimension.");
+          "Stimulus box Minimum and Maximum must have the same coordinate dimension.");
     }
 
     if (box_min_vals.size() != static_cast<std::size_t>(nsd)) {
       svmp::raise<svmp::ParseException>(
-          SVMP_HERE, "Stimulus box coordinate dimension must match the simulation spatial dimension.");
+          "Stimulus box coordinate dimension must match the simulation spatial dimension.");
     }
 
     Vector<double> box_min(box_min_vals.size());
@@ -210,14 +200,14 @@ void stimType::read_parameters(const StimulusParameters& params, const int nsd, 
     for (int i = 0; i < static_cast<int>(box_min_vals.size()); i++) {
       if (box_min_vals[i] > box_max_vals[i]) {
         svmp::raise<svmp::ParseException>(
-            SVMP_HERE, "Stimulus box Minimum values must be less than or equal to Maximum values.");
+            "Stimulus box Minimum values must be less than or equal to Maximum values.");
       }
 
-      box_min(i) = box_min_vals[i];
-      box_max(i) = box_max_vals[i];
+      box_min[i] = box_min_vals[i];
+      box_max[i] = box_max_vals[i];
     }
 
-    spatial_bounds_.set_box(box_min, box_max);
+    spatial_bounds.set_box(box_min, box_max);
   }
 
   const auto& sphere_params = spatial_bounds_params.sphere;
@@ -227,7 +217,7 @@ void stimType::read_parameters(const StimulusParameters& params, const int nsd, 
 
   if (sphere_is_defined && !(sphere_center_defined && sphere_radius_defined)) {
     svmp::raise<svmp::ParseException>(
-        SVMP_HERE, "Both Center and Radius must be specified for a CEP stimulus sphere.");
+        "Both Center and Radius must be specified for a CEP stimulus sphere.");
   }
 
   if (sphere_is_defined) {
@@ -236,21 +226,21 @@ void stimType::read_parameters(const StimulusParameters& params, const int nsd, 
 
     if (sphere_center_vals.size() != static_cast<std::size_t>(nsd)) {
       svmp::raise<svmp::ParseException>(
-          SVMP_HERE, "Stimulus sphere center coordinate dimension must match the simulation spatial dimension.");
+          "Stimulus sphere center coordinate dimension must match the simulation spatial dimension.");
     }
 
     if (sphere_radius_val < 0.0) {
       svmp::raise<svmp::ParseException>(
-          SVMP_HERE, "Stimulus sphere Radius must be non-negative.");
+          "Stimulus sphere Radius must be non-negative.");
     }
 
     Vector<double> sphere_center(sphere_center_vals.size());
 
     for (int i = 0; i < static_cast<int>(sphere_center_vals.size()); i++) {
-      sphere_center(i) = sphere_center_vals[i];
+      sphere_center[i] = sphere_center_vals[i];
     }
 
-    spatial_bounds_.set_sphere(sphere_center, sphere_radius_val);
+    spatial_bounds.set_sphere(sphere_center, sphere_radius_val);
   }
 }
 

--- a/Code/Source/solver/CepMod.cpp
+++ b/Code/Source/solver/CepMod.cpp
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "CepMod.h"
+
+#include "ComMod.h"
+#include "FE/Common/FEException.h"
+
+#include <limits>
 #include <math.h>
 
 const std::map<ElectrophysiologyModelType, std::string> cep_model_type_to_name{
@@ -23,6 +28,124 @@ const std::map<std::string,ElectrophysiologyModelType> cep_model_name_to_type
   {"tentusscher-panfilov", ElectrophysiologyModelType::TTP},
   {"ttp", ElectrophysiologyModelType::TTP}
 };
+
+bool stimType::is_active(const double time) const
+{
+  const double eps = std::numeric_limits<double>::epsilon();
+
+  const int icl = static_cast<int>(fmax(floor(time / CL), 0.0));
+  const double Ts_cycle = Ts + static_cast<double>(icl) * CL;
+  const double Te_cycle = Ts_cycle + Td;
+
+  return Ts_cycle - eps <= time && time <= Te_cycle + eps;
+}
+
+bool stimType::inside_box(const ComMod& com_mod, const int Ac) const
+{
+  if (box_min.size() < com_mod.nsd || box_max.size() < com_mod.nsd) {
+    svmp::raise<svmp::FE::InvalidArgumentException>(
+        SVMP_HERE, "Stimulus box dimension is smaller than the simulation spatial dimension.");
+  }
+
+  for (int i = 0; i < com_mod.nsd; i++) {
+    const double xi = com_mod.x(i, Ac);
+
+    if (xi < box_min(i) || xi > box_max(i)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool stimType::inside_sphere(const ComMod& com_mod, const int Ac) const
+{
+  if (sphere_center.size() < com_mod.nsd) {
+    svmp::raise<svmp::FE::InvalidArgumentException>(
+        SVMP_HERE, "Stimulus sphere center dimension is smaller than the simulation spatial dimension.");
+  }
+
+  double distance_squared = 0.0;
+
+  for (int i = 0; i < com_mod.nsd; i++) {
+    const double dx = com_mod.x(i, Ac) - sphere_center(i);
+    distance_squared += dx * dx;
+  }
+
+  return distance_squared <= sphere_radius * sphere_radius;
+}
+
+bool stimType::contains_node(const ComMod& com_mod, const int Ac) const
+{
+  if (box_defined && !inside_box(com_mod, Ac)) {
+    return false;
+  }
+
+  if (sphere_defined && !inside_sphere(com_mod, Ac)) {
+    return false;
+  }
+
+  return true;
+}
+
+double stimType::operator()(const double time, const ComMod& com_mod, const int Ac) const
+{
+  if (!is_active(time)) {
+    return 0.0;
+  }
+
+  if (!contains_node(com_mod, Ac)) {
+    return 0.0;
+  }
+
+  return A;
+}
+
+void stimType::distribute(const CmMod& cm_mod, const cmType& cm)
+{
+  cm.bcast(cm_mod, &Ts);
+  cm.bcast(cm_mod, &Td);
+  cm.bcast(cm_mod, &CL);
+  cm.bcast(cm_mod, &A);
+  cm.bcast(cm_mod, &box_defined);
+
+  if (box_defined) {
+    int box_size = box_min.size();
+    cm.bcast(cm_mod, &box_size);
+
+    if (box_size <= 0) {
+      svmp::raise<svmp::FE::InvalidArgumentException>(
+          SVMP_HERE, "Stimulus box has invalid coordinate dimension.");
+    }
+
+    if (cm.slv(cm_mod)) {
+      box_min.resize(box_size);
+      box_max.resize(box_size);
+    }
+
+    cm.bcast(cm_mod, box_min, "Stimulus box_min");
+    cm.bcast(cm_mod, box_max, "Stimulus box_max");
+  }
+
+  cm.bcast(cm_mod, &sphere_defined);
+
+  if (sphere_defined) {
+    int sphere_center_size = sphere_center.size();
+    cm.bcast(cm_mod, &sphere_center_size);
+
+    if (sphere_center_size <= 0) {
+      svmp::raise<svmp::FE::InvalidArgumentException>(
+          SVMP_HERE, "Stimulus sphere center has invalid coordinate dimension.");
+    }
+
+    if (cm.slv(cm_mod)) {
+      sphere_center.resize(sphere_center_size);
+    }
+
+    cm.bcast(cm_mod, sphere_center, "Stimulus sphere_center");
+    cm.bcast(cm_mod, &sphere_radius);
+  }
+}
 
 cepModelType::cepModelType()
 {

--- a/Code/Source/solver/CepMod.cpp
+++ b/Code/Source/solver/CepMod.cpp
@@ -5,6 +5,8 @@
 
 #include "ComMod.h"
 #include "FE/Common/FEException.h"
+#include "Parameters.h"
+#include "utils.h"
 
 #include <limits>
 #include <math.h>
@@ -40,17 +42,29 @@ bool stimType::is_active(const double time) const
   return Ts_cycle - eps <= time && time <= Te_cycle + eps;
 }
 
-bool stimType::inside_box(const ComMod& com_mod, const int Ac) const
+void SpatialBounds::set_box(const Vector<double>& min, const Vector<double>& max)
 {
-  if (box_min.size() < com_mod.nsd || box_max.size() < com_mod.nsd) {
+  box_min_ = min;
+  box_max_ = max;
+  region_type_ = (region_type_ == RegionType::sphere) ? RegionType::both : RegionType::box;
+}
+
+void SpatialBounds::set_sphere(const Vector<double>& center, const double radius)
+{
+  sphere_center_ = center;
+  sphere_radius_ = radius;
+  region_type_ = (region_type_ == RegionType::box) ? RegionType::both : RegionType::sphere;
+}
+
+bool SpatialBounds::inside_box(const Vector<double>& x) const
+{
+  if (x.size() != box_min_.size()) {
     svmp::raise<svmp::FE::InvalidArgumentException>(
-        SVMP_HERE, "Stimulus box dimension is smaller than the simulation spatial dimension.");
+        SVMP_HERE, "Point dimension does not match stimulus box dimension.");
   }
 
-  for (int i = 0; i < com_mod.nsd; i++) {
-    const double xi = com_mod.x(i, Ac);
-
-    if (xi < box_min(i) || xi > box_max(i)) {
+  for (int i = 0; i < x.size(); i++) {
+    if (x(i) < box_min_(i) || x(i) > box_max_(i)) {
       return false;
     }
   }
@@ -58,43 +72,87 @@ bool stimType::inside_box(const ComMod& com_mod, const int Ac) const
   return true;
 }
 
-bool stimType::inside_sphere(const ComMod& com_mod, const int Ac) const
+bool SpatialBounds::inside_sphere(const Vector<double>& x) const
 {
-  if (sphere_center.size() < com_mod.nsd) {
+  if (x.size() != sphere_center_.size()) {
     svmp::raise<svmp::FE::InvalidArgumentException>(
-        SVMP_HERE, "Stimulus sphere center dimension is smaller than the simulation spatial dimension.");
+        SVMP_HERE, "Point dimension does not match stimulus sphere dimension.");
   }
 
   double distance_squared = 0.0;
 
-  for (int i = 0; i < com_mod.nsd; i++) {
-    const double dx = com_mod.x(i, Ac) - sphere_center(i);
+  for (int i = 0; i < x.size(); i++) {
+    const double dx = x(i) - sphere_center_(i);
     distance_squared += dx * dx;
   }
 
-  return distance_squared <= sphere_radius * sphere_radius;
+  return distance_squared <= sphere_radius_ * sphere_radius_;
 }
 
-bool stimType::contains_node(const ComMod& com_mod, const int Ac) const
+bool SpatialBounds::contains(const Vector<double>& x) const
 {
-  if (box_defined && !inside_box(com_mod, Ac)) {
-    return false;
+  switch (region_type_) {
+    case RegionType::none:   return true;
+    case RegionType::box:    return inside_box(x);
+    case RegionType::sphere: return inside_sphere(x);
+    case RegionType::both:   return inside_box(x) && inside_sphere(x);
   }
-
-  if (sphere_defined && !inside_sphere(com_mod, Ac)) {
-    return false;
-  }
-
   return true;
 }
 
-double stimType::operator()(const double time, const ComMod& com_mod, const int Ac) const
+void SpatialBounds::distribute(const CmMod& cm_mod, const cmType& cm)
 {
+  int region_type_int = static_cast<int>(region_type_);
+  cm.bcast(cm_mod, &region_type_int);
+  region_type_ = static_cast<RegionType>(region_type_int);
+
+  if (region_type_ == RegionType::box || region_type_ == RegionType::both) {
+    int box_size = box_min_.size();
+    cm.bcast(cm_mod, &box_size);
+
+    if (box_size <= 0) {
+      svmp::raise<svmp::FE::InvalidArgumentException>(
+          SVMP_HERE, "Stimulus box has invalid coordinate dimension.");
+    }
+
+    if (cm.slv(cm_mod)) {
+      box_min_.resize(box_size);
+      box_max_.resize(box_size);
+    }
+
+    cm.bcast(cm_mod, box_min_, "SpatialBounds box_min");
+    cm.bcast(cm_mod, box_max_, "SpatialBounds box_max");
+  }
+
+  if (region_type_ == RegionType::sphere || region_type_ == RegionType::both) {
+    int sphere_center_size = sphere_center_.size();
+    cm.bcast(cm_mod, &sphere_center_size);
+
+    if (sphere_center_size <= 0) {
+      svmp::raise<svmp::FE::InvalidArgumentException>(
+          SVMP_HERE, "Stimulus sphere center has invalid coordinate dimension.");
+    }
+
+    if (cm.slv(cm_mod)) {
+      sphere_center_.resize(sphere_center_size);
+    }
+
+    cm.bcast(cm_mod, sphere_center_, "SpatialBounds sphere_center");
+    cm.bcast(cm_mod, &sphere_radius_);
+  }
+}
+
+double stimType::operator()(const double time, const Vector<double>& x) const
+{
+  if (utils::is_zero(A)) {
+    return 0.0;
+  }
+
   if (!is_active(time)) {
     return 0.0;
   }
 
-  if (!contains_node(com_mod, Ac)) {
+  if (!spatial_bounds_.contains(x)) {
     return 0.0;
   }
 
@@ -107,43 +165,92 @@ void stimType::distribute(const CmMod& cm_mod, const cmType& cm)
   cm.bcast(cm_mod, &Td);
   cm.bcast(cm_mod, &CL);
   cm.bcast(cm_mod, &A);
-  cm.bcast(cm_mod, &box_defined);
+  spatial_bounds_.distribute(cm_mod, cm);
+}
 
-  if (box_defined) {
-    int box_size = box_min.size();
-    cm.bcast(cm_mod, &box_size);
+void stimType::read_parameters(const StimulusParameters& params, const int nsd, const double default_cycle_length)
+{
+  A = params.amplitude.value();
 
-    if (box_size <= 0) {
-      svmp::raise<svmp::FE::InvalidArgumentException>(
-          SVMP_HERE, "Stimulus box has invalid coordinate dimension.");
-    }
-
-    if (cm.slv(cm_mod)) {
-      box_min.resize(box_size);
-      box_max.resize(box_size);
-    }
-
-    cm.bcast(cm_mod, box_min, "Stimulus box_min");
-    cm.bcast(cm_mod, box_max, "Stimulus box_max");
+  if (!utils::is_zero(A)) {
+    Ts = params.start_time.value();
+    Td = params.duration.value();
+    CL = params.cycle_length.defined() ? params.cycle_length.value() : default_cycle_length;
   }
 
-  cm.bcast(cm_mod, &sphere_defined);
+  const auto& spatial_bounds_params = params.spatial_bounds;
 
-  if (sphere_defined) {
-    int sphere_center_size = sphere_center.size();
-    cm.bcast(cm_mod, &sphere_center_size);
+  const auto& box_params = spatial_bounds_params.box;
+  const bool box_is_defined = box_params.defined();
+  const bool box_min_defined = box_params.minimum.defined();
+  const bool box_max_defined = box_params.maximum.defined();
 
-    if (sphere_center_size <= 0) {
-      svmp::raise<svmp::FE::InvalidArgumentException>(
-          SVMP_HERE, "Stimulus sphere center has invalid coordinate dimension.");
+  if (box_is_defined && !(box_min_defined && box_max_defined)) {
+    svmp::raise<svmp::ParseException>(
+        SVMP_HERE, "Both Minimum and Maximum must be specified for a CEP stimulus box.");
+  }
+
+  if (box_is_defined) {
+    const auto& box_min_vals = box_params.minimum.value();
+    const auto& box_max_vals = box_params.maximum.value();
+
+    if (box_min_vals.size() != box_max_vals.size()) {
+      svmp::raise<svmp::ParseException>(
+          SVMP_HERE, "Stimulus box Minimum and Maximum must have the same coordinate dimension.");
     }
 
-    if (cm.slv(cm_mod)) {
-      sphere_center.resize(sphere_center_size);
+    if (box_min_vals.size() < static_cast<std::size_t>(nsd)) {
+      svmp::raise<svmp::ParseException>(
+          SVMP_HERE, "Stimulus box dimension is smaller than the simulation spatial dimension.");
     }
 
-    cm.bcast(cm_mod, sphere_center, "Stimulus sphere_center");
-    cm.bcast(cm_mod, &sphere_radius);
+    Vector<double> box_min(box_min_vals.size());
+    Vector<double> box_max(box_max_vals.size());
+
+    for (int i = 0; i < static_cast<int>(box_min_vals.size()); i++) {
+      if (box_min_vals[i] > box_max_vals[i]) {
+        svmp::raise<svmp::ParseException>(
+            SVMP_HERE, "Stimulus box Minimum values must be less than or equal to Maximum values.");
+      }
+
+      box_min(i) = box_min_vals[i];
+      box_max(i) = box_max_vals[i];
+    }
+
+    spatial_bounds_.set_box(box_min, box_max);
+  }
+
+  const auto& sphere_params = spatial_bounds_params.sphere;
+  const bool sphere_is_defined = sphere_params.defined();
+  const bool sphere_center_defined = sphere_params.center.defined();
+  const bool sphere_radius_defined = sphere_params.radius.defined();
+
+  if (sphere_is_defined && !(sphere_center_defined && sphere_radius_defined)) {
+    svmp::raise<svmp::ParseException>(
+        SVMP_HERE, "Both Center and Radius must be specified for a CEP stimulus sphere.");
+  }
+
+  if (sphere_is_defined) {
+    const auto& sphere_center_vals = sphere_params.center.value();
+    const double sphere_radius_val = sphere_params.radius.value();
+
+    if (sphere_center_vals.size() < static_cast<std::size_t>(nsd)) {
+      svmp::raise<svmp::ParseException>(
+          SVMP_HERE, "Stimulus sphere center dimension is smaller than the simulation spatial dimension.");
+    }
+
+    if (sphere_radius_val < 0.0) {
+      svmp::raise<svmp::ParseException>(
+          SVMP_HERE, "Stimulus sphere Radius must be non-negative.");
+    }
+
+    Vector<double> sphere_center(sphere_center_vals.size());
+
+    for (int i = 0; i < static_cast<int>(sphere_center_vals.size()); i++) {
+      sphere_center(i) = sphere_center_vals[i];
+    }
+
+    spatial_bounds_.set_sphere(sphere_center, sphere_radius_val);
   }
 }
 

--- a/Code/Source/solver/CepMod.h
+++ b/Code/Source/solver/CepMod.h
@@ -94,10 +94,10 @@ class stimType
     void distribute(const CmMod& cm_mod, const cmType& cm);
 
   private:
-    double Ts = 0.0;
-    double Td = 0.0;
-    double CL = 0.0;
-    double A = 0.0;
+    double start_time_ = 0.0;
+    double duration_ = 0.0;
+    double cycle_length_ = 0.0;
+    double amplitude_ = 0.0;
 
     SpatialBounds spatial_bounds_;
 

--- a/Code/Source/solver/CepMod.h
+++ b/Code/Source/solver/CepMod.h
@@ -59,6 +59,15 @@ class stimType
 
     /// @brief stimulus amplitude
     double A = 0.0;
+
+    /// @brief Whether the stimulus is restricted to a coordinate box.
+    bool box_defined = false;
+
+    /// @brief Minimum coordinates for the stimulus box.
+    Vector<double> box_min;
+
+    /// @brief Maximum coordinates for the stimulus box.
+    Vector<double> box_max;
 };
 
 /// @brief ECG leads type

--- a/Code/Source/solver/CepMod.h
+++ b/Code/Source/solver/CepMod.h
@@ -68,6 +68,15 @@ class stimType
 
     /// @brief Maximum coordinates for the stimulus box.
     Vector<double> box_max;
+
+    /// @brief Whether the stimulus is restricted to a sphere.
+    bool sphere_defined = false;
+
+    /// @brief Center coordinates for the stimulus sphere.
+    Vector<double> sphere_center;
+
+    /// @brief Radius of the stimulus sphere.
+    double sphere_radius = 0.0;
 };
 
 /// @brief ECG leads type

--- a/Code/Source/solver/CepMod.h
+++ b/Code/Source/solver/CepMod.h
@@ -44,6 +44,10 @@ static std::ostream &operator << ( std::ostream& strm, ElectrophysiologyModelTyp
   return strm << names.at(type);
 }
 
+class ComMod;
+class CmMod;
+class cmType;
+
 /// @brief External stimulus type
 class stimType
 {
@@ -77,6 +81,25 @@ class stimType
 
     /// @brief Radius of the stimulus sphere.
     double sphere_radius = 0.0;
+
+    /// @brief Return the applied stimulus value at a node and time.
+    double operator()(const double time, const ComMod& com_mod, const int Ac) const;
+
+    /// @brief Broadcast stimulus parameters to all ranks.
+    void distribute(const CmMod& cm_mod, const cmType& cm);
+
+  private:
+    /// @brief Check whether the stimulus is active at the given time.
+    bool is_active(const double time) const;
+
+    /// @brief Check whether a node lies inside all active spatial bounds.
+    bool contains_node(const ComMod& com_mod, const int Ac) const;
+
+    /// @brief Check whether a node lies inside the stimulus box.
+    bool inside_box(const ComMod& com_mod, const int Ac) const;
+
+    /// @brief Check whether a node lies inside the stimulus sphere.
+    bool inside_sphere(const ComMod& com_mod, const int Ac) const;
 };
 
 /// @brief ECG leads type

--- a/Code/Source/solver/CepMod.h
+++ b/Code/Source/solver/CepMod.h
@@ -50,40 +50,39 @@ class ComMod;
 class CmMod;
 class cmType;
 
-/// @brief Spatial bounds for a CEP stimulus region.
-class SpatialBounds
-{
-  public:
-    enum class RegionType { none, box, sphere, both };
-
-    /// @brief Set box bounds. Updates region type to box or both.
-    void set_box(const Vector<double>& min, const Vector<double>& max);
-
-    /// @brief Set sphere bounds. Updates region type to sphere or both.
-    void set_sphere(const Vector<double>& center, const double radius);
-
-    /// @brief Return true if the point lies inside all active spatial bounds.
-    bool contains(const Vector<double>& x) const;
-
-    /// @brief Broadcast spatial bounds to all MPI ranks.
-    void distribute(const CmMod& cm_mod, const cmType& cm);
-
-  private:
-    RegionType region_type_ = RegionType::none;
-
-    Vector<double> box_min_;
-    Vector<double> box_max_;
-    Vector<double> sphere_center_;
-    double sphere_radius_ = 0.0;
-
-    bool inside_box(const Vector<double>& x) const;
-    bool inside_sphere(const Vector<double>& x) const;
-};
-
 /// @brief External stimulus type
 class stimType
 {
   public:
+    /// @brief Spatial bounds for a CEP stimulus region.
+    class SpatialBounds
+    {
+      public:
+        /// @brief Set box bounds.
+        void set_box(const Vector<double>& min, const Vector<double>& max);
+
+        /// @brief Set sphere bounds.
+        void set_sphere(const Vector<double>& center, const double radius);
+
+        /// @brief Return true if the point lies inside all active spatial bounds.
+        bool contains(const Vector<double>& x) const;
+
+        /// @brief Broadcast spatial bounds to all MPI ranks.
+        void distribute(const CmMod& cm_mod, const cmType& cm);
+
+      private:
+        bool has_box = false;
+        bool has_sphere = false;
+
+        Vector<double> box_min;
+        Vector<double> box_max;
+        Vector<double> sphere_center;
+        double sphere_radius = 0.0;
+
+        bool inside_box(const Vector<double>& x) const;
+        bool inside_sphere(const Vector<double>& x) const;
+    };
+
     /// @brief Return the applied stimulus value at a point and time.
     double operator()(const double time, const Vector<double>& x) const;
 
@@ -94,12 +93,12 @@ class stimType
     void distribute(const CmMod& cm_mod, const cmType& cm);
 
   private:
-    double start_time_ = 0.0;
-    double duration_ = 0.0;
-    double cycle_length_ = 0.0;
-    double amplitude_ = 0.0;
+    double start_time = 0.0;
+    double duration = 0.0;
+    double cycle_length = 0.0;
+    double amplitude = 0.0;
 
-    SpatialBounds spatial_bounds_;
+    SpatialBounds spatial_bounds;
 
     bool is_active(const double time) const;
 };

--- a/Code/Source/solver/CepMod.h
+++ b/Code/Source/solver/CepMod.h
@@ -19,6 +19,8 @@
 #include <map>
 #include <memory>
 
+class StimulusParameters;
+
 /// @brief Type of cardiac electrophysiology models.
 enum class ElectrophysiologyModelType {
   NA = 100, 
@@ -48,58 +50,58 @@ class ComMod;
 class CmMod;
 class cmType;
 
+/// @brief Spatial bounds for a CEP stimulus region.
+class SpatialBounds
+{
+  public:
+    enum class RegionType { none, box, sphere, both };
+
+    /// @brief Set box bounds. Updates region type to box or both.
+    void set_box(const Vector<double>& min, const Vector<double>& max);
+
+    /// @brief Set sphere bounds. Updates region type to sphere or both.
+    void set_sphere(const Vector<double>& center, const double radius);
+
+    /// @brief Return true if the point lies inside all active spatial bounds.
+    bool contains(const Vector<double>& x) const;
+
+    /// @brief Broadcast spatial bounds to all MPI ranks.
+    void distribute(const CmMod& cm_mod, const cmType& cm);
+
+  private:
+    RegionType region_type_ = RegionType::none;
+
+    Vector<double> box_min_;
+    Vector<double> box_max_;
+    Vector<double> sphere_center_;
+    double sphere_radius_ = 0.0;
+
+    bool inside_box(const Vector<double>& x) const;
+    bool inside_sphere(const Vector<double>& x) const;
+};
+
 /// @brief External stimulus type
 class stimType
 {
   public:
-    /// @brief start time
-    double Ts = 0.0;
+    /// @brief Return the applied stimulus value at a point and time.
+    double operator()(const double time, const Vector<double>& x) const;
 
-    /// @brief duration of stimulus
-    double Td = 0.0;
-
-    /// @brief cycle length
-    double CL = 0.0;
-
-    /// @brief stimulus amplitude
-    double A = 0.0;
-
-    /// @brief Whether the stimulus is restricted to a coordinate box.
-    bool box_defined = false;
-
-    /// @brief Minimum coordinates for the stimulus box.
-    Vector<double> box_min;
-
-    /// @brief Maximum coordinates for the stimulus box.
-    Vector<double> box_max;
-
-    /// @brief Whether the stimulus is restricted to a sphere.
-    bool sphere_defined = false;
-
-    /// @brief Center coordinates for the stimulus sphere.
-    Vector<double> sphere_center;
-
-    /// @brief Radius of the stimulus sphere.
-    double sphere_radius = 0.0;
-
-    /// @brief Return the applied stimulus value at a node and time.
-    double operator()(const double time, const ComMod& com_mod, const int Ac) const;
+    /// @brief Set stimulus parameters from parsed XML parameters.
+    void read_parameters(const StimulusParameters& params, const int nsd, const double default_cycle_length);
 
     /// @brief Broadcast stimulus parameters to all ranks.
     void distribute(const CmMod& cm_mod, const cmType& cm);
 
   private:
-    /// @brief Check whether the stimulus is active at the given time.
+    double Ts = 0.0;
+    double Td = 0.0;
+    double CL = 0.0;
+    double A = 0.0;
+
+    SpatialBounds spatial_bounds_;
+
     bool is_active(const double time) const;
-
-    /// @brief Check whether a node lies inside all active spatial bounds.
-    bool contains_node(const ComMod& com_mod, const int Ac) const;
-
-    /// @brief Check whether a node lies inside the stimulus box.
-    bool inside_box(const ComMod& com_mod, const int Ac) const;
-
-    /// @brief Check whether a node lies inside the stimulus sphere.
-    bool inside_sphere(const ComMod& com_mod, const int Ac) const;
 };
 
 /// @brief ECG leads type

--- a/Code/Source/solver/CepMod.h
+++ b/Code/Source/solver/CepMod.h
@@ -19,8 +19,6 @@
 #include <map>
 #include <memory>
 
-class StimulusParameters;
-
 /// @brief Type of cardiac electrophysiology models.
 enum class ElectrophysiologyModelType {
   NA = 100, 
@@ -49,6 +47,7 @@ static std::ostream &operator << ( std::ostream& strm, ElectrophysiologyModelTyp
 class ComMod;
 class CmMod;
 class cmType;
+class StimulusParameters;
 
 /// @brief External stimulus type
 class stimType
@@ -71,15 +70,23 @@ class stimType
         void distribute(const CmMod& cm_mod, const cmType& cm);
 
       private:
+        /// @brief True if a box region has been set.
         bool has_box = false;
+        /// @brief True if a sphere region has been set.
         bool has_sphere = false;
 
+        /// @brief Minimum corner of the box region.
         Vector<double> box_min;
+        /// @brief Maximum corner of the box region.
         Vector<double> box_max;
+        /// @brief Center of the sphere region.
         Vector<double> sphere_center;
+        /// @brief Radius of the sphere region.
         double sphere_radius = 0.0;
 
+        /// @brief Return true if x lies inside the box. Assumes has_box is true.
         bool inside_box(const Vector<double>& x) const;
+        /// @brief Return true if x lies inside the sphere. Assumes has_sphere is true.
         bool inside_sphere(const Vector<double>& x) const;
     };
 
@@ -93,13 +100,19 @@ class stimType
     void distribute(const CmMod& cm_mod, const cmType& cm);
 
   private:
+    /// @brief Time at which the stimulus begins within each cycle.
     double start_time = 0.0;
+    /// @brief Duration of the stimulus pulse within each cycle.
     double duration = 0.0;
+    /// @brief Length of one stimulus cycle.
     double cycle_length = 0.0;
+    /// @brief Amplitude of the applied stimulus.
     double amplitude = 0.0;
 
+    /// @brief Spatial region to which the stimulus is applied.
     SpatialBounds spatial_bounds;
 
+    /// @brief Return true if the stimulus is active at the given time.
     bool is_active(const double time) const;
 };
 

--- a/Code/Source/solver/Parameters.cpp
+++ b/Code/Source/solver/Parameters.cpp
@@ -2124,6 +2124,84 @@ void FiberReinforcementStressParameters::print_parameters()
 // 'Stimulus' XML element used to parameters for 
 // pacemaker cells.
 
+/// @brief Define the XML element name for CEP stimulus box spatial bounds.
+const std::string StimulusBoxParameters::xml_element_name_ = "Box";
+
+StimulusBoxParameters::StimulusBoxParameters()
+{
+  bool required = true;
+
+  set_parameter("Minimum", {}, !required, minimum);
+  set_parameter("Maximum", {}, !required, maximum);
+}
+
+void StimulusBoxParameters::set_values(tinyxml2::XMLElement* xml_elem)
+{
+  std::string error_msg = "Unknown " + xml_element_name_ + " XML element '";
+
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+
+  std::function<void(const std::string&, const std::string&)> ftpr =
+      std::bind(&StimulusBoxParameters::set_parameter_value, *this, _1, _2);
+
+  xml_util_set_parameters(ftpr, xml_elem, error_msg);
+
+  value_set = true;
+}
+
+/// @brief Define the XML element name for CEP stimulus sphere spatial bounds.
+const std::string StimulusSphereParameters::xml_element_name_ = "Sphere";
+
+StimulusSphereParameters::StimulusSphereParameters()
+{
+  bool required = true;
+
+  set_parameter("Center", {}, !required, center);
+  set_parameter("Radius", 0.0, !required, radius);
+}
+
+void StimulusSphereParameters::set_values(tinyxml2::XMLElement* xml_elem)
+{
+  std::string error_msg = "Unknown " + xml_element_name_ + " XML element '";
+
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+
+  std::function<void(const std::string&, const std::string&)> ftpr =
+      std::bind(&StimulusSphereParameters::set_parameter_value, *this, _1, _2);
+
+  xml_util_set_parameters(ftpr, xml_elem, error_msg);
+
+  value_set = true;
+}
+
+/// @brief Define the XML element name for CEP stimulus spatial bounds.
+const std::string StimulusSpatialBoundsParameters::xml_element_name_ = "Spatial_bounds";
+
+void StimulusSpatialBoundsParameters::set_values(tinyxml2::XMLElement* xml_elem)
+{
+  std::string error_msg = "Unknown " + xml_element_name_ + " XML element '";
+
+  auto item = xml_elem->FirstChildElement();
+
+  while (item != nullptr) {
+    auto name = std::string(item->Value());
+
+    if (name == StimulusBoxParameters::xml_element_name_) {
+      box.set_values(item);
+    } else if (name == StimulusSphereParameters::xml_element_name_) {
+      sphere.set_values(item);
+    } else {
+      svmp::raise<svmp::ParseException>(SVMP_HERE, error_msg + name + "'.");
+    }
+
+    item = item->NextSiblingElement();
+  }
+
+  value_set = true;
+}
+
 /// @brief Define the XML element name for equation output parameters.
 const std::string StimulusParameters::xml_element_name_ = "Stimulus";
 
@@ -2139,28 +2217,36 @@ StimulusParameters::StimulusParameters()
   set_parameter("Cycle_length", 0.0, !required, cycle_length);
   set_parameter("Duration", 0.0, !required, duration);
   set_parameter("Start_time", 0.0, !required, start_time);
-  set_parameter("Box_min", {}, !required, box_min);
-  set_parameter("Box_max", {}, !required, box_max);
-  set_parameter("Sphere_center", {}, !required, sphere_center);
-  set_parameter("Sphere_radius", 0.0, !required, sphere_radius);
 }
 
 void StimulusParameters::set_values(tinyxml2::XMLElement* xml_elem)
 {
   std::string error_msg = "Unknown " + xml_element_name_ + " XML element '";
 
-  // Get the 'type' from the <LS type=TYPE> element.
+  // Get the 'type' from the <Stimulus type=TYPE> element.
   const char* stype = require_xml_attribute(xml_elem, "type");
   type.set(std::string(stype));
-  auto item = xml_elem->FirstChildElement();
-  
+
   using std::placeholders::_1;
   using std::placeholders::_2;
 
   std::function<void(const std::string&, const std::string&)> ftpr =
-      std::bind( &StimulusParameters::set_parameter_value, *this, _1, _2);
+      std::bind(&StimulusParameters::set_parameter_value, *this, _1, _2);
 
-  xml_util_set_parameters(ftpr, xml_elem, error_msg);
+  std::set<std::string> sub_sections = {StimulusSpatialBoundsParameters::xml_element_name_};
+  xml_util_set_parameters(ftpr, xml_elem, error_msg, sub_sections);
+
+  auto item = xml_elem->FirstChildElement();
+
+  while (item != nullptr) {
+    auto name = std::string(item->Value());
+
+    if (name == StimulusSpatialBoundsParameters::xml_element_name_) {
+      spatial_bounds.set_values(item);
+    }
+
+    item = item->NextSiblingElement();
+  }
 
   value_set = true;
 }

--- a/Code/Source/solver/Parameters.cpp
+++ b/Code/Source/solver/Parameters.cpp
@@ -2141,6 +2141,8 @@ StimulusParameters::StimulusParameters()
   set_parameter("Start_time", 0.0, !required, start_time);
   set_parameter("Box_min", {}, !required, box_min);
   set_parameter("Box_max", {}, !required, box_max);
+  set_parameter("Sphere_center", {}, !required, sphere_center);
+  set_parameter("Sphere_radius", 0.0, !required, sphere_radius);
 }
 
 void StimulusParameters::set_values(tinyxml2::XMLElement* xml_elem)

--- a/Code/Source/solver/Parameters.cpp
+++ b/Code/Source/solver/Parameters.cpp
@@ -2139,6 +2139,8 @@ StimulusParameters::StimulusParameters()
   set_parameter("Cycle_length", 0.0, !required, cycle_length);
   set_parameter("Duration", 0.0, !required, duration);
   set_parameter("Start_time", 0.0, !required, start_time);
+  set_parameter("Box_min", {}, !required, box_min);
+  set_parameter("Box_max", {}, !required, box_max);
 }
 
 void StimulusParameters::set_values(tinyxml2::XMLElement* xml_elem)

--- a/Code/Source/solver/Parameters.cpp
+++ b/Code/Source/solver/Parameters.cpp
@@ -2188,7 +2188,7 @@ void StimulusSpatialBoundsParameters::set_values(tinyxml2::XMLElement* xml_elem)
     } else if (name == StimulusSphereParameters::xml_element_name_) {
       sphere.set_values(item);
     } else {
-      svmp::raise<svmp::ParseException>(SVMP_HERE, error_msg + name + "'.");
+      svmp::raise<svmp::ParseException>(error_msg + name + "'.");
     }
   }
 

--- a/Code/Source/solver/Parameters.cpp
+++ b/Code/Source/solver/Parameters.cpp
@@ -2124,7 +2124,6 @@ void FiberReinforcementStressParameters::print_parameters()
 // 'Stimulus' XML element used to parameters for 
 // pacemaker cells.
 
-/// @brief Define the XML element name for CEP stimulus box spatial bounds.
 const std::string StimulusBoxParameters::xml_element_name_ = "Box";
 
 StimulusBoxParameters::StimulusBoxParameters()
@@ -2150,7 +2149,6 @@ void StimulusBoxParameters::set_values(tinyxml2::XMLElement* xml_elem)
   value_set = true;
 }
 
-/// @brief Define the XML element name for CEP stimulus sphere spatial bounds.
 const std::string StimulusSphereParameters::xml_element_name_ = "Sphere";
 
 StimulusSphereParameters::StimulusSphereParameters()
@@ -2176,16 +2174,13 @@ void StimulusSphereParameters::set_values(tinyxml2::XMLElement* xml_elem)
   value_set = true;
 }
 
-/// @brief Define the XML element name for CEP stimulus spatial bounds.
 const std::string StimulusSpatialBoundsParameters::xml_element_name_ = "Spatial_bounds";
 
 void StimulusSpatialBoundsParameters::set_values(tinyxml2::XMLElement* xml_elem)
 {
   std::string error_msg = "Unknown " + xml_element_name_ + " XML element '";
 
-  auto item = xml_elem->FirstChildElement();
-
-  while (item != nullptr) {
+  for (auto item = xml_elem->FirstChildElement(); item != nullptr; item = item->NextSiblingElement()) {
     auto name = std::string(item->Value());
 
     if (name == StimulusBoxParameters::xml_element_name_) {
@@ -2195,14 +2190,11 @@ void StimulusSpatialBoundsParameters::set_values(tinyxml2::XMLElement* xml_elem)
     } else {
       svmp::raise<svmp::ParseException>(SVMP_HERE, error_msg + name + "'.");
     }
-
-    item = item->NextSiblingElement();
   }
 
   value_set = true;
 }
 
-/// @brief Define the XML element name for equation output parameters.
 const std::string StimulusParameters::xml_element_name_ = "Stimulus";
 
 StimulusParameters::StimulusParameters()

--- a/Code/Source/solver/Parameters.h
+++ b/Code/Source/solver/Parameters.h
@@ -1084,6 +1084,7 @@ class StimulusBoxParameters : public ParameterLists
   public:
     StimulusBoxParameters();
 
+    /// @brief XML element name for CEP stimulus box spatial bounds.
     static const std::string xml_element_name_;
 
     bool defined() const { return value_set; };
@@ -1101,6 +1102,7 @@ class StimulusSphereParameters : public ParameterLists
   public:
     StimulusSphereParameters();
 
+    /// @brief XML element name for CEP stimulus sphere spatial bounds.
     static const std::string xml_element_name_;
 
     bool defined() const { return value_set; };
@@ -1116,6 +1118,7 @@ class StimulusSphereParameters : public ParameterLists
 class StimulusSpatialBoundsParameters
 {
   public:
+    /// @brief XML element name for CEP stimulus spatial bounds.
     static const std::string xml_element_name_;
 
     bool defined() const { return value_set; };
@@ -1150,10 +1153,11 @@ class StimulusSpatialBoundsParameters
 /// </Stimulus>
 /// \endcode
 class StimulusParameters : public ParameterLists
-{ 
+{
   public:
     StimulusParameters();
 
+    /// @brief XML element name for CEP stimulus parameters.
     static const std::string xml_element_name_;
     
     bool defined() const { return value_set; };

--- a/Code/Source/solver/Parameters.h
+++ b/Code/Source/solver/Parameters.h
@@ -1078,6 +1078,55 @@ class LinearSolverParameters : public ParameterLists
     LinearAlgebraParameters linear_algebra;
 };
 
+/// @brief Stores <Box> parameters for CEP stimulus spatial bounds.
+class StimulusBoxParameters : public ParameterLists
+{
+  public:
+    StimulusBoxParameters();
+
+    static const std::string xml_element_name_;
+
+    bool defined() const { return value_set; };
+    void set_values(tinyxml2::XMLElement* xml_elem);
+
+    VectorParameter<double> minimum;
+    VectorParameter<double> maximum;
+
+    bool value_set = false;
+};
+
+/// @brief Stores <Sphere> parameters for CEP stimulus spatial bounds.
+class StimulusSphereParameters : public ParameterLists
+{
+  public:
+    StimulusSphereParameters();
+
+    static const std::string xml_element_name_;
+
+    bool defined() const { return value_set; };
+    void set_values(tinyxml2::XMLElement* xml_elem);
+
+    VectorParameter<double> center;
+    Parameter<double> radius;
+
+    bool value_set = false;
+};
+
+/// @brief Stores <Spatial_bounds> parameters for CEP stimulus geometry restrictions.
+class StimulusSpatialBoundsParameters
+{
+  public:
+    static const std::string xml_element_name_;
+
+    bool defined() const { return value_set; };
+    void set_values(tinyxml2::XMLElement* xml_elem);
+
+    StimulusBoxParameters box;
+    StimulusSphereParameters sphere;
+
+    bool value_set = false;
+};
+
 /// @brief The StimulusParameters class stores parameters for 
 /// 'Stimulus' XML element used to parameters for 
 /// pacemaker cells.
@@ -1088,10 +1137,16 @@ class LinearSolverParameters : public ParameterLists
 ///   <Start_time> 0.0 </Start_time>
 ///   <Duration> 1.0 </Duration>
 ///   <Cycle_length> 10000.0 </Cycle_length>
-///   <Box_min> 0.0 0.0 0.0 </Box_min>
-///   <Box_max> 1.0 1.0 1.0 </Box_max>
-///   <Sphere_center> 0.5 0.5 0.5 </Sphere_center>
-///   <Sphere_radius> 0.25 </Sphere_radius>
+///   <Spatial_bounds>
+///     <Box>
+///       <Minimum> 0.0 0.0 0.0 </Minimum>
+///       <Maximum> 1.0 1.0 1.0 </Maximum>
+///     </Box>
+///     <Sphere>
+///       <Center> 0.5 0.5 0.5 </Center>
+///       <Radius> 0.25 </Radius>
+///     </Sphere>
+///   </Spatial_bounds>
 /// </Stimulus>
 /// \endcode
 class StimulusParameters : public ParameterLists
@@ -1112,11 +1167,7 @@ class StimulusParameters : public ParameterLists
     Parameter<double> duration;
     Parameter<double> start_time;
 
-    VectorParameter<double> box_min;
-    VectorParameter<double> box_max;
-
-    VectorParameter<double> sphere_center;
-    Parameter<double> sphere_radius;
+    StimulusSpatialBoundsParameters spatial_bounds;
     
     bool value_set = false;
 };

--- a/Code/Source/solver/Parameters.h
+++ b/Code/Source/solver/Parameters.h
@@ -1088,6 +1088,10 @@ class LinearSolverParameters : public ParameterLists
 ///   <Start_time> 0.0 </Start_time>
 ///   <Duration> 1.0 </Duration>
 ///   <Cycle_length> 10000.0 </Cycle_length>
+///   <Box_min> 0.0 0.0 0.0 </Box_min>
+///   <Box_max> 1.0 1.0 1.0 </Box_max>
+///   <Sphere_center> 0.5 0.5 0.5 </Sphere_center>
+///   <Sphere_radius> 0.25 </Sphere_radius>
 /// </Stimulus>
 /// \endcode
 class StimulusParameters : public ParameterLists
@@ -1110,6 +1114,9 @@ class StimulusParameters : public ParameterLists
 
     VectorParameter<double> box_min;
     VectorParameter<double> box_max;
+
+    VectorParameter<double> sphere_center;
+    Parameter<double> sphere_radius;
     
     bool value_set = false;
 };

--- a/Code/Source/solver/Parameters.h
+++ b/Code/Source/solver/Parameters.h
@@ -1107,6 +1107,9 @@ class StimulusParameters : public ParameterLists
     Parameter<double> cycle_length;
     Parameter<double> duration;
     Parameter<double> start_time;
+
+    VectorParameter<double> box_min;
+    VectorParameter<double> box_max;
     
     bool value_set = false;
 };

--- a/Code/Source/solver/cep_ion.cpp
+++ b/Code/Source/solver/cep_ion.cpp
@@ -16,6 +16,27 @@ namespace cep_ion {
 ///   cep_mod.Xion
 /// \endcode
 //
+static bool node_in_stimulus_box(const ComMod& com_mod, const stimType& stim, const int Ac)
+{
+  if (!stim.box_defined) {
+    return true;
+  }
+
+  if (stim.box_min.size() < com_mod.nsd || stim.box_max.size() < com_mod.nsd) {
+    throw std::runtime_error("Stimulus box dimension is smaller than the simulation spatial dimension.");
+  }
+
+  for (int i = 0; i < com_mod.nsd; i++) {
+    const double xi = com_mod.x(i, Ac);
+
+    if (xi < stim.box_min(i) || xi > stim.box_max(i)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 void cep_init(Simulation* simulation)
 {
   using namespace consts;
@@ -221,7 +242,13 @@ void cep_integ(Simulation* simulation, const int iEq, const int iDof, SolutionSt
           yl = cem.Ya(Ac);
         }
 
-        cep_integ_l(cep_mod, dmn.cep, Xl, Xgl, time - dt, yl, I4f(Ac), dt);
+        double stimulus_amplitude = dmn.cep.Istim.A;
+
+        if (!node_in_stimulus_box(com_mod, dmn.cep.Istim, Ac)) {
+          stimulus_amplitude = 0.0;
+        }
+
+        cep_integ_l(cep_mod, dmn.cep, Xl, Xgl, time - dt, yl, I4f(Ac), dt, stimulus_amplitude);
 
         sA(Ac) = sA(Ac) + 1.0;
         for (int i = 0; i < nX; i++) {
@@ -270,7 +297,13 @@ void cep_integ(Simulation* simulation, const int iEq, const int iDof, SolutionSt
         yl = cem.Ya(Ac);
       }
 
-      cep_integ_l(cep_mod, eq.dmn[0].cep, Xl, Xgl, time - dt, yl, I4f(Ac), dt);
+      double stimulus_amplitude = eq.dmn[0].cep.Istim.A;
+
+      if (!node_in_stimulus_box(com_mod, eq.dmn[0].cep.Istim, Ac)) {
+        stimulus_amplitude = 0.0;
+      }
+
+      cep_integ_l(cep_mod, eq.dmn[0].cep, Xl, Xgl, time - dt, yl, I4f(Ac), dt, stimulus_amplitude);
 
       for (int i = 0; i < nX; i++) {
         Xion(i,Ac) = Xl(i);
@@ -300,7 +333,8 @@ void cep_integ(Simulation* simulation, const int iEq, const int iDof, SolutionSt
 //
 void cep_integ_l(CepMod &cep_mod, cepModelType &cep, Vector<double> &X,
                  Vector<double> &Xg, const double t1, double &yl,
-                 const double I4f, const double dt) {
+                 const double I4f, const double dt,
+                 const double stimulus_amplitude) {
   using namespace consts;
 
   #define n_debug_cep_integ_l
@@ -337,7 +371,7 @@ void cep_integ_l(CepMod &cep_mod, cepModelType &cep, Vector<double> &X,
 
   for (unsigned int i = 0; i < nt; ++i) {
     const double t = t1 + i * dt;
-    const double Istim = (Ts - eps <= t && t <= Te + eps) ? cep.Istim.A : 0.0;
+    const double Istim = (Ts - eps <= t && t <= Te + eps) ? stimulus_amplitude : 0.0;
 
     cep.ionic_model->integ(cep.odes, cep.imyo, t, cep.dt, Istim, Ksac, X, Xg);
   }

--- a/Code/Source/solver/cep_ion.cpp
+++ b/Code/Source/solver/cep_ion.cpp
@@ -221,7 +221,7 @@ void cep_integ(Simulation* simulation, const int iEq, const int iDof, SolutionSt
           yl = cem.Ya(Ac);
         }
 
-        cep_integ_l(cep_mod, dmn.cep, Xl, Xgl, time - dt, yl, I4f(Ac), dt, com_mod, Ac);
+        cep_integ_l(cep_mod, dmn.cep, Xl, Xgl, time - dt, yl, I4f(Ac), dt, com_mod.x.col(Ac));
 
         sA(Ac) = sA(Ac) + 1.0;
         for (int i = 0; i < nX; i++) {
@@ -270,7 +270,7 @@ void cep_integ(Simulation* simulation, const int iEq, const int iDof, SolutionSt
         yl = cem.Ya(Ac);
       }
 
-      cep_integ_l(cep_mod, eq.dmn[0].cep, Xl, Xgl, time - dt, yl, I4f(Ac), dt, com_mod, Ac);
+      cep_integ_l(cep_mod, eq.dmn[0].cep, Xl, Xgl, time - dt, yl, I4f(Ac), dt, com_mod.x.col(Ac));
 
       for (int i = 0; i < nX; i++) {
         Xion(i,Ac) = Xl(i);
@@ -301,12 +301,12 @@ void cep_integ(Simulation* simulation, const int iEq, const int iDof, SolutionSt
 void cep_integ_l(CepMod &cep_mod, cepModelType &cep, Vector<double> &X,
                  Vector<double> &Xg, const double t1, double &yl,
                  const double I4f, const double dt,
-                 const ComMod& com_mod, const int Ac) {
+                 const Vector<double>& x) {
   using namespace consts;
 
   #define n_debug_cep_integ_l
   #ifdef debug_cep_integ_l
-  DebugMsg dmsg(__func__, com_mod.cm.idcm());
+  DebugMsg dmsg(__func__, cep_mod.cm.idcm());
   dmsg.banner();
   #endif
 
@@ -328,7 +328,7 @@ void cep_integ_l(CepMod &cep_mod, cepModelType &cep, Vector<double> &X,
 
   for (unsigned int i = 0; i < nt; ++i) {
     const double t = t1 + i * dt;
-    const double Istim = cep.Istim(t, com_mod, Ac);
+    const double Istim = cep.Istim(t, x);
 
     cep.ionic_model->integ(cep.odes, cep.imyo, t, cep.dt, Istim, Ksac, X, Xg);
   }

--- a/Code/Source/solver/cep_ion.cpp
+++ b/Code/Source/solver/cep_ion.cpp
@@ -16,20 +16,35 @@ namespace cep_ion {
 ///   cep_mod.Xion
 /// \endcode
 //
-static bool node_in_stimulus_box(const ComMod& com_mod, const stimType& stim, const int Ac)
+static bool node_in_stimulus_geometry(const ComMod& com_mod, const stimType& stim, const int Ac)
 {
-  if (!stim.box_defined) {
-    return true;
+  if (stim.box_defined) {
+    if (stim.box_min.size() < com_mod.nsd || stim.box_max.size() < com_mod.nsd) {
+      throw std::runtime_error("Stimulus box dimension is smaller than the simulation spatial dimension.");
+    }
+
+    for (int i = 0; i < com_mod.nsd; i++) {
+      const double xi = com_mod.x(i, Ac);
+
+      if (xi < stim.box_min(i) || xi > stim.box_max(i)) {
+        return false;
+      }
+    }
   }
 
-  if (stim.box_min.size() < com_mod.nsd || stim.box_max.size() < com_mod.nsd) {
-    throw std::runtime_error("Stimulus box dimension is smaller than the simulation spatial dimension.");
-  }
+  if (stim.sphere_defined) {
+    if (stim.sphere_center.size() < com_mod.nsd) {
+      throw std::runtime_error("Stimulus sphere center dimension is smaller than the simulation spatial dimension.");
+    }
 
-  for (int i = 0; i < com_mod.nsd; i++) {
-    const double xi = com_mod.x(i, Ac);
+    double distance_squared = 0.0;
 
-    if (xi < stim.box_min(i) || xi > stim.box_max(i)) {
+    for (int i = 0; i < com_mod.nsd; i++) {
+      const double dx = com_mod.x(i, Ac) - stim.sphere_center(i);
+      distance_squared += dx * dx;
+    }
+
+    if (distance_squared > stim.sphere_radius * stim.sphere_radius) {
       return false;
     }
   }
@@ -244,7 +259,7 @@ void cep_integ(Simulation* simulation, const int iEq, const int iDof, SolutionSt
 
         double stimulus_amplitude = dmn.cep.Istim.A;
 
-        if (!node_in_stimulus_box(com_mod, dmn.cep.Istim, Ac)) {
+        if (!node_in_stimulus_geometry(com_mod, dmn.cep.Istim, Ac)) {
           stimulus_amplitude = 0.0;
         }
 
@@ -299,7 +314,7 @@ void cep_integ(Simulation* simulation, const int iEq, const int iDof, SolutionSt
 
       double stimulus_amplitude = eq.dmn[0].cep.Istim.A;
 
-      if (!node_in_stimulus_box(com_mod, eq.dmn[0].cep.Istim, Ac)) {
+      if (!node_in_stimulus_geometry(com_mod, eq.dmn[0].cep.Istim, Ac)) {
         stimulus_amplitude = 0.0;
       }
 

--- a/Code/Source/solver/cep_ion.cpp
+++ b/Code/Source/solver/cep_ion.cpp
@@ -16,42 +16,6 @@ namespace cep_ion {
 ///   cep_mod.Xion
 /// \endcode
 //
-static bool node_in_stimulus_geometry(const ComMod& com_mod, const stimType& stim, const int Ac)
-{
-  if (stim.box_defined) {
-    if (stim.box_min.size() < com_mod.nsd || stim.box_max.size() < com_mod.nsd) {
-      throw std::runtime_error("Stimulus box dimension is smaller than the simulation spatial dimension.");
-    }
-
-    for (int i = 0; i < com_mod.nsd; i++) {
-      const double xi = com_mod.x(i, Ac);
-
-      if (xi < stim.box_min(i) || xi > stim.box_max(i)) {
-        return false;
-      }
-    }
-  }
-
-  if (stim.sphere_defined) {
-    if (stim.sphere_center.size() < com_mod.nsd) {
-      throw std::runtime_error("Stimulus sphere center dimension is smaller than the simulation spatial dimension.");
-    }
-
-    double distance_squared = 0.0;
-
-    for (int i = 0; i < com_mod.nsd; i++) {
-      const double dx = com_mod.x(i, Ac) - stim.sphere_center(i);
-      distance_squared += dx * dx;
-    }
-
-    if (distance_squared > stim.sphere_radius * stim.sphere_radius) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 void cep_init(Simulation* simulation)
 {
   using namespace consts;
@@ -257,13 +221,7 @@ void cep_integ(Simulation* simulation, const int iEq, const int iDof, SolutionSt
           yl = cem.Ya(Ac);
         }
 
-        double stimulus_amplitude = dmn.cep.Istim.A;
-
-        if (!node_in_stimulus_geometry(com_mod, dmn.cep.Istim, Ac)) {
-          stimulus_amplitude = 0.0;
-        }
-
-        cep_integ_l(cep_mod, dmn.cep, Xl, Xgl, time - dt, yl, I4f(Ac), dt, stimulus_amplitude);
+        cep_integ_l(cep_mod, dmn.cep, Xl, Xgl, time - dt, yl, I4f(Ac), dt, com_mod, Ac);
 
         sA(Ac) = sA(Ac) + 1.0;
         for (int i = 0; i < nX; i++) {
@@ -312,13 +270,7 @@ void cep_integ(Simulation* simulation, const int iEq, const int iDof, SolutionSt
         yl = cem.Ya(Ac);
       }
 
-      double stimulus_amplitude = eq.dmn[0].cep.Istim.A;
-
-      if (!node_in_stimulus_geometry(com_mod, eq.dmn[0].cep.Istim, Ac)) {
-        stimulus_amplitude = 0.0;
-      }
-
-      cep_integ_l(cep_mod, eq.dmn[0].cep, Xl, Xgl, time - dt, yl, I4f(Ac), dt, stimulus_amplitude);
+      cep_integ_l(cep_mod, eq.dmn[0].cep, Xl, Xgl, time - dt, yl, I4f(Ac), dt, com_mod, Ac);
 
       for (int i = 0; i < nX; i++) {
         Xion(i,Ac) = Xl(i);
@@ -349,7 +301,7 @@ void cep_integ(Simulation* simulation, const int iEq, const int iDof, SolutionSt
 void cep_integ_l(CepMod &cep_mod, cepModelType &cep, Vector<double> &X,
                  Vector<double> &Xg, const double t1, double &yl,
                  const double I4f, const double dt,
-                 const double stimulus_amplitude) {
+                 const ComMod& com_mod, const int Ac) {
   using namespace consts;
 
   #define n_debug_cep_integ_l
@@ -364,17 +316,9 @@ void cep_integ_l(CepMod &cep_mod, cepModelType &cep, Vector<double> &X,
   // Total time steps
   const unsigned nt = static_cast<unsigned int>(dt / cep.dt);
 
-  // External stimulus duration
-  const int icl = static_cast<int>(fmax(floor(t1 / cep.Istim.CL), 0.0));
-  const double Ts = cep.Istim.Ts + static_cast<double>(icl) * cep.Istim.CL;
-  const double Te = Ts + cep.Istim.Td;
-
   #ifdef debug_cep_integ_l
   dmsg << "nt: " << nt;
   dmsg << "Ksac: " << Ksac;
-  dmsg << "icl: " << icl;
-  dmsg << "Ts: " << Ts;
-  dmsg << "Te: " << Te;
   dmsg << "cep.cepType: " << cep.cepType;
   dmsg << "cep.odes.tIntTyp: " << cep.odes.tIntType;
   #endif
@@ -382,11 +326,9 @@ void cep_integ_l(CepMod &cep_mod, cepModelType &cep, Vector<double> &X,
   svmp::check_not_null<svmp::FE::NotInitializedException>(
       cep.ionic_model, "ionic model was not constructed.");
 
-  const double eps = std::numeric_limits<double>::epsilon();
-
   for (unsigned int i = 0; i < nt; ++i) {
     const double t = t1 + i * dt;
-    const double Istim = (Ts - eps <= t && t <= Te + eps) ? stimulus_amplitude : 0.0;
+    const double Istim = cep.Istim(t, com_mod, Ac);
 
     cep.ionic_model->integ(cep.odes, cep.imyo, t, cep.dt, Istim, Ksac, X, Xg);
   }

--- a/Code/Source/solver/cep_ion.h
+++ b/Code/Source/solver/cep_ion.h
@@ -23,7 +23,7 @@ void cep_integ(Simulation* simulation, const int iEq, const int iDof, SolutionSt
 void cep_integ_l(CepMod &cep_mod, cepModelType &cep, Vector<double> &X,
                  Vector<double> &Xg, const double t1, double &yl,
                  const double I4f, const double dt,
-                 const double stimulus_amplitude);
+                 const ComMod& com_mod, const int Ac);
 };
 
 #endif

--- a/Code/Source/solver/cep_ion.h
+++ b/Code/Source/solver/cep_ion.h
@@ -22,7 +22,8 @@ void cep_integ(Simulation* simulation, const int iEq, const int iDof, SolutionSt
 
 void cep_integ_l(CepMod &cep_mod, cepModelType &cep, Vector<double> &X,
                  Vector<double> &Xg, const double t1, double &yl,
-                 const double I4f, const double dt);
+                 const double I4f, const double dt,
+                 const double stimulus_amplitude);
 };
 
 #endif

--- a/Code/Source/solver/cep_ion.h
+++ b/Code/Source/solver/cep_ion.h
@@ -23,7 +23,7 @@ void cep_integ(Simulation* simulation, const int iEq, const int iDof, SolutionSt
 void cep_integ_l(CepMod &cep_mod, cepModelType &cep, Vector<double> &X,
                  Vector<double> &Xg, const double t1, double &yl,
                  const double I4f, const double dt,
-                 const ComMod& com_mod, const int Ac);
+                 const Vector<double>& x);
 };
 
 #endif

--- a/Code/Source/solver/distribute.cpp
+++ b/Code/Source/solver/distribute.cpp
@@ -1622,6 +1622,24 @@ void dist_eq(ComMod& com_mod, const CmMod& cm_mod, const cmType& cm, const std::
         cm.bcast(cm_mod, cep.Istim.box_max, "Stimulus box_max");
       }
 
+      cm.bcast(cm_mod, &cep.Istim.sphere_defined);
+
+      if (cep.Istim.sphere_defined) {
+        int sphere_center_size = cep.Istim.sphere_center.size();
+        cm.bcast(cm_mod, &sphere_center_size);
+
+        if (sphere_center_size <= 0) {
+          throw std::runtime_error("Stimulus sphere center has invalid coordinate dimension.");
+        }
+
+        if (cm.slv(cm_mod)) {
+          cep.Istim.sphere_center.resize(sphere_center_size);
+        }
+
+        cm.bcast(cm_mod, cep.Istim.sphere_center, "Stimulus sphere_center");
+        cm.bcast(cm_mod, &cep.Istim.sphere_radius);
+      }
+
       cm.bcast_enum(cm_mod, &cep.odes.tIntType);
 
       if (cep.odes.tIntType == TimeIntegrationType::CN2) {

--- a/Code/Source/solver/distribute.cpp
+++ b/Code/Source/solver/distribute.cpp
@@ -1599,46 +1599,8 @@ void dist_eq(ComMod& com_mod, const CmMod& cm_mod, const cmType& cm, const std::
       } 
 
       cm.bcast(cm_mod, cep.Dani);
-      cm.bcast(cm_mod, &cep.Istim.Ts);
-      cm.bcast(cm_mod, &cep.Istim.Td);
-      cm.bcast(cm_mod, &cep.Istim.CL);
-      cm.bcast(cm_mod, &cep.Istim.A);
-      cm.bcast(cm_mod, &cep.Istim.box_defined);
 
-      if (cep.Istim.box_defined) {
-        int box_size = cep.Istim.box_min.size();
-        cm.bcast(cm_mod, &box_size);
-
-        if (box_size <= 0) {
-          throw std::runtime_error("Stimulus box has invalid coordinate dimension.");
-        }
-
-        if (cm.slv(cm_mod)) {
-          cep.Istim.box_min.resize(box_size);
-          cep.Istim.box_max.resize(box_size);
-        }
-
-        cm.bcast(cm_mod, cep.Istim.box_min, "Stimulus box_min");
-        cm.bcast(cm_mod, cep.Istim.box_max, "Stimulus box_max");
-      }
-
-      cm.bcast(cm_mod, &cep.Istim.sphere_defined);
-
-      if (cep.Istim.sphere_defined) {
-        int sphere_center_size = cep.Istim.sphere_center.size();
-        cm.bcast(cm_mod, &sphere_center_size);
-
-        if (sphere_center_size <= 0) {
-          throw std::runtime_error("Stimulus sphere center has invalid coordinate dimension.");
-        }
-
-        if (cm.slv(cm_mod)) {
-          cep.Istim.sphere_center.resize(sphere_center_size);
-        }
-
-        cm.bcast(cm_mod, cep.Istim.sphere_center, "Stimulus sphere_center");
-        cm.bcast(cm_mod, &cep.Istim.sphere_radius);
-      }
+      cep.Istim.distribute(cm_mod, cm);
 
       cm.bcast_enum(cm_mod, &cep.odes.tIntType);
 

--- a/Code/Source/solver/distribute.cpp
+++ b/Code/Source/solver/distribute.cpp
@@ -1603,6 +1603,25 @@ void dist_eq(ComMod& com_mod, const CmMod& cm_mod, const cmType& cm, const std::
       cm.bcast(cm_mod, &cep.Istim.Td);
       cm.bcast(cm_mod, &cep.Istim.CL);
       cm.bcast(cm_mod, &cep.Istim.A);
+      cm.bcast(cm_mod, &cep.Istim.box_defined);
+
+      if (cep.Istim.box_defined) {
+        int box_size = cep.Istim.box_min.size();
+        cm.bcast(cm_mod, &box_size);
+
+        if (box_size <= 0) {
+          throw std::runtime_error("Stimulus box has invalid coordinate dimension.");
+        }
+
+        if (cm.slv(cm_mod)) {
+          cep.Istim.box_min.resize(box_size);
+          cep.Istim.box_max.resize(box_size);
+        }
+
+        cm.bcast(cm_mod, cep.Istim.box_min, "Stimulus box_min");
+        cm.bcast(cm_mod, cep.Istim.box_max, "Stimulus box_max");
+      }
+
       cm.bcast_enum(cm_mod, &cep.odes.tIntType);
 
       if (cep.odes.tIntType == TimeIntegrationType::CN2) {

--- a/Code/Source/solver/read_files.cpp
+++ b/Code/Source/solver/read_files.cpp
@@ -1106,7 +1106,8 @@ void read_cep_domain(Simulation* simulation, EquationParameters* eq_params, Doma
     const bool box_max_defined = stimulus_params.box_max.defined();
 
     if (box_min_defined != box_max_defined) {
-      throw std::runtime_error("Both Box_min and Box_max must be specified for a CEP stimulus box.");
+      svmp::raise<svmp::ParseException>(
+          SVMP_HERE, "Both Box_min and Box_max must be specified for a CEP stimulus box.");
     }
 
     if (box_min_defined && box_max_defined) {
@@ -1114,11 +1115,13 @@ void read_cep_domain(Simulation* simulation, EquationParameters* eq_params, Doma
       const auto& box_max = stimulus_params.box_max.value();
 
       if (box_min.size() != box_max.size()) {
-        throw std::runtime_error("Stimulus Box_min and Box_max must have the same coordinate dimension.");
+        svmp::raise<svmp::ParseException>(
+            SVMP_HERE, "Stimulus Box_min and Box_max must have the same coordinate dimension.");
       }
 
       if (box_min.size() < static_cast<std::size_t>(simulation->com_mod.nsd)) {
-        throw std::runtime_error("Stimulus box dimension is smaller than the simulation spatial dimension.");
+        svmp::raise<svmp::ParseException>(
+            SVMP_HERE, "Stimulus box dimension is smaller than the simulation spatial dimension.");
       }
 
       lDmn.cep.Istim.box_defined = true;
@@ -1127,7 +1130,8 @@ void read_cep_domain(Simulation* simulation, EquationParameters* eq_params, Doma
 
       for (int i = 0; i < static_cast<int>(box_min.size()); i++) {
         if (box_min[i] > box_max[i]) {
-          throw std::runtime_error("Stimulus Box_min values must be less than or equal to Box_max values.");
+          svmp::raise<svmp::ParseException>(
+              SVMP_HERE, "Stimulus Box_min values must be less than or equal to Box_max values.");
         }
 
         lDmn.cep.Istim.box_min(i) = box_min[i];
@@ -1139,7 +1143,8 @@ void read_cep_domain(Simulation* simulation, EquationParameters* eq_params, Doma
     const bool sphere_radius_defined = stimulus_params.sphere_radius.defined();
 
     if (sphere_center_defined != sphere_radius_defined) {
-      throw std::runtime_error("Both Sphere_center and Sphere_radius must be specified for a CEP stimulus sphere.");
+      svmp::raise<svmp::ParseException>(
+          SVMP_HERE, "Both Sphere_center and Sphere_radius must be specified for a CEP stimulus sphere.");
     }
 
     if (sphere_center_defined && sphere_radius_defined) {
@@ -1147,11 +1152,13 @@ void read_cep_domain(Simulation* simulation, EquationParameters* eq_params, Doma
       const double sphere_radius = stimulus_params.sphere_radius.value();
 
       if (sphere_center.size() < static_cast<std::size_t>(simulation->com_mod.nsd)) {
-        throw std::runtime_error("Stimulus sphere center dimension is smaller than the simulation spatial dimension.");
+        svmp::raise<svmp::ParseException>(
+            SVMP_HERE, "Stimulus sphere center dimension is smaller than the simulation spatial dimension.");
       }
 
       if (sphere_radius < 0.0) {
-        throw std::runtime_error("Stimulus Sphere_radius must be non-negative.");
+        svmp::raise<svmp::ParseException>(
+            SVMP_HERE, "Stimulus Sphere_radius must be non-negative.");
       }
 
       lDmn.cep.Istim.sphere_defined = true;

--- a/Code/Source/solver/read_files.cpp
+++ b/Code/Source/solver/read_files.cpp
@@ -1098,6 +1098,39 @@ void read_cep_domain(Simulation* simulation, EquationParameters* eq_params, Doma
         lDmn.cep.Istim.CL = simulation->nTs * simulation->com_mod.dt; 
       }
     }
+
+    const bool box_min_defined = stimulus_params.box_min.defined();
+    const bool box_max_defined = stimulus_params.box_max.defined();
+
+    if (box_min_defined != box_max_defined) {
+      throw std::runtime_error("Both Box_min and Box_max must be specified for a CEP stimulus box.");
+    }
+
+    if (box_min_defined && box_max_defined) {
+      const auto& box_min = stimulus_params.box_min.value();
+      const auto& box_max = stimulus_params.box_max.value();
+
+      if (box_min.size() != box_max.size()) {
+        throw std::runtime_error("Stimulus Box_min and Box_max must have the same coordinate dimension.");
+      }
+
+      if (box_min.size() < static_cast<std::size_t>(simulation->com_mod.nsd)) {
+        throw std::runtime_error("Stimulus box dimension is smaller than the simulation spatial dimension.");
+      }
+
+      lDmn.cep.Istim.box_defined = true;
+      lDmn.cep.Istim.box_min.resize(box_min.size());
+      lDmn.cep.Istim.box_max.resize(box_max.size());
+
+      for (int i = 0; i < static_cast<int>(box_min.size()); i++) {
+        if (box_min[i] > box_max[i]) {
+          throw std::runtime_error("Stimulus Box_min values must be less than or equal to Box_max values.");
+        }
+
+        lDmn.cep.Istim.box_min(i) = box_min[i];
+        lDmn.cep.Istim.box_max(i) = box_max[i];
+      }
+    }
   }
 
   // Dual time step for cellular activation model.

--- a/Code/Source/solver/read_files.cpp
+++ b/Code/Source/solver/read_files.cpp
@@ -1079,102 +1079,11 @@ void read_cep_domain(Simulation* simulation, EquationParameters* eq_params, Doma
     }
   }
 
-  // Set stimulus parameters. 
+  // Set stimulus parameters.
   //
-  lDmn.cep.Istim.A  = 0.0;
-  lDmn.cep.Istim.Ts = 99999.0;
-  lDmn.cep.Istim.CL = 99999.0;
-  lDmn.cep.Istim.Td = 0.0;
-  lDmn.cep.Istim.box_defined = false;
-  lDmn.cep.Istim.sphere_defined = false;
-  lDmn.cep.Istim.sphere_radius = 0.0;
-
-  if (domain_params->stimulus.defined()) { 
-    auto& stimulus_params = domain_params->stimulus;
-    lDmn.cep.Istim.A = stimulus_params.amplitude.value();
-    if (!utils::is_zero(lDmn.cep.Istim.A)) {
-      lDmn.cep.Istim.Ts = stimulus_params.start_time.value();
-      lDmn.cep.Istim.Td = stimulus_params.duration.value();
-      if (stimulus_params.cycle_length.defined()) { 
-        lDmn.cep.Istim.CL = stimulus_params.cycle_length.value();
-      } else {
-        lDmn.cep.Istim.CL = simulation->nTs * simulation->com_mod.dt; 
-      }
-    }
-
-    const auto& spatial_bounds_params = stimulus_params.spatial_bounds;
-
-    const auto& box_params = spatial_bounds_params.box;
-    const bool box_defined = box_params.defined();
-    const bool box_min_defined = box_params.minimum.defined();
-    const bool box_max_defined = box_params.maximum.defined();
-
-    if (box_defined && !(box_min_defined && box_max_defined)) {
-      svmp::raise<svmp::ParseException>(
-          SVMP_HERE, "Both Minimum and Maximum must be specified for a CEP stimulus box.");
-    }
-
-    if (box_defined) {
-      const auto& box_min = box_params.minimum.value();
-      const auto& box_max = box_params.maximum.value();
-
-      if (box_min.size() != box_max.size()) {
-        svmp::raise<svmp::ParseException>(
-            SVMP_HERE, "Stimulus box Minimum and Maximum must have the same coordinate dimension.");
-      }
-
-      if (box_min.size() < static_cast<std::size_t>(simulation->com_mod.nsd)) {
-        svmp::raise<svmp::ParseException>(
-            SVMP_HERE, "Stimulus box dimension is smaller than the simulation spatial dimension.");
-      }
-
-      lDmn.cep.Istim.box_defined = true;
-      lDmn.cep.Istim.box_min.resize(box_min.size());
-      lDmn.cep.Istim.box_max.resize(box_max.size());
-
-      for (int i = 0; i < static_cast<int>(box_min.size()); i++) {
-        if (box_min[i] > box_max[i]) {
-          svmp::raise<svmp::ParseException>(
-              SVMP_HERE, "Stimulus box Minimum values must be less than or equal to Maximum values.");
-        }
-
-        lDmn.cep.Istim.box_min(i) = box_min[i];
-        lDmn.cep.Istim.box_max(i) = box_max[i];
-      }
-    }
-
-    const auto& sphere_params = spatial_bounds_params.sphere;
-    const bool sphere_defined = sphere_params.defined();
-    const bool sphere_center_defined = sphere_params.center.defined();
-    const bool sphere_radius_defined = sphere_params.radius.defined();
-
-    if (sphere_defined && !(sphere_center_defined && sphere_radius_defined)) {
-      svmp::raise<svmp::ParseException>(
-          SVMP_HERE, "Both Center and Radius must be specified for a CEP stimulus sphere.");
-    }
-
-    if (sphere_defined) {
-      const auto& sphere_center = sphere_params.center.value();
-      const double sphere_radius = sphere_params.radius.value();
-
-      if (sphere_center.size() < static_cast<std::size_t>(simulation->com_mod.nsd)) {
-        svmp::raise<svmp::ParseException>(
-            SVMP_HERE, "Stimulus sphere center dimension is smaller than the simulation spatial dimension.");
-      }
-
-      if (sphere_radius < 0.0) {
-        svmp::raise<svmp::ParseException>(
-            SVMP_HERE, "Stimulus sphere Radius must be non-negative.");
-      }
-
-      lDmn.cep.Istim.sphere_defined = true;
-      lDmn.cep.Istim.sphere_center.resize(sphere_center.size());
-      lDmn.cep.Istim.sphere_radius = sphere_radius;
-
-      for (int i = 0; i < static_cast<int>(sphere_center.size()); i++) {
-        lDmn.cep.Istim.sphere_center(i) = sphere_center[i];
-      }
-    }
+  if (domain_params->stimulus.defined()) {
+    const double default_cycle_length = simulation->nTs * simulation->com_mod.dt;
+    lDmn.cep.Istim.read_parameters(domain_params->stimulus, simulation->com_mod.nsd, default_cycle_length);
   }
 
   // Dual time step for cellular activation model.

--- a/Code/Source/solver/read_files.cpp
+++ b/Code/Source/solver/read_files.cpp
@@ -1102,21 +1102,25 @@ void read_cep_domain(Simulation* simulation, EquationParameters* eq_params, Doma
       }
     }
 
-    const bool box_min_defined = stimulus_params.box_min.defined();
-    const bool box_max_defined = stimulus_params.box_max.defined();
+    const auto& spatial_bounds_params = stimulus_params.spatial_bounds;
 
-    if (box_min_defined != box_max_defined) {
+    const auto& box_params = spatial_bounds_params.box;
+    const bool box_defined = box_params.defined();
+    const bool box_min_defined = box_params.minimum.defined();
+    const bool box_max_defined = box_params.maximum.defined();
+
+    if (box_defined && !(box_min_defined && box_max_defined)) {
       svmp::raise<svmp::ParseException>(
-          SVMP_HERE, "Both Box_min and Box_max must be specified for a CEP stimulus box.");
+          SVMP_HERE, "Both Minimum and Maximum must be specified for a CEP stimulus box.");
     }
 
-    if (box_min_defined && box_max_defined) {
-      const auto& box_min = stimulus_params.box_min.value();
-      const auto& box_max = stimulus_params.box_max.value();
+    if (box_defined) {
+      const auto& box_min = box_params.minimum.value();
+      const auto& box_max = box_params.maximum.value();
 
       if (box_min.size() != box_max.size()) {
         svmp::raise<svmp::ParseException>(
-            SVMP_HERE, "Stimulus Box_min and Box_max must have the same coordinate dimension.");
+            SVMP_HERE, "Stimulus box Minimum and Maximum must have the same coordinate dimension.");
       }
 
       if (box_min.size() < static_cast<std::size_t>(simulation->com_mod.nsd)) {
@@ -1131,7 +1135,7 @@ void read_cep_domain(Simulation* simulation, EquationParameters* eq_params, Doma
       for (int i = 0; i < static_cast<int>(box_min.size()); i++) {
         if (box_min[i] > box_max[i]) {
           svmp::raise<svmp::ParseException>(
-              SVMP_HERE, "Stimulus Box_min values must be less than or equal to Box_max values.");
+              SVMP_HERE, "Stimulus box Minimum values must be less than or equal to Maximum values.");
         }
 
         lDmn.cep.Istim.box_min(i) = box_min[i];
@@ -1139,17 +1143,19 @@ void read_cep_domain(Simulation* simulation, EquationParameters* eq_params, Doma
       }
     }
 
-    const bool sphere_center_defined = stimulus_params.sphere_center.defined();
-    const bool sphere_radius_defined = stimulus_params.sphere_radius.defined();
+    const auto& sphere_params = spatial_bounds_params.sphere;
+    const bool sphere_defined = sphere_params.defined();
+    const bool sphere_center_defined = sphere_params.center.defined();
+    const bool sphere_radius_defined = sphere_params.radius.defined();
 
-    if (sphere_center_defined != sphere_radius_defined) {
+    if (sphere_defined && !(sphere_center_defined && sphere_radius_defined)) {
       svmp::raise<svmp::ParseException>(
-          SVMP_HERE, "Both Sphere_center and Sphere_radius must be specified for a CEP stimulus sphere.");
+          SVMP_HERE, "Both Center and Radius must be specified for a CEP stimulus sphere.");
     }
 
-    if (sphere_center_defined && sphere_radius_defined) {
-      const auto& sphere_center = stimulus_params.sphere_center.value();
-      const double sphere_radius = stimulus_params.sphere_radius.value();
+    if (sphere_defined) {
+      const auto& sphere_center = sphere_params.center.value();
+      const double sphere_radius = sphere_params.radius.value();
 
       if (sphere_center.size() < static_cast<std::size_t>(simulation->com_mod.nsd)) {
         svmp::raise<svmp::ParseException>(
@@ -1158,7 +1164,7 @@ void read_cep_domain(Simulation* simulation, EquationParameters* eq_params, Doma
 
       if (sphere_radius < 0.0) {
         svmp::raise<svmp::ParseException>(
-            SVMP_HERE, "Stimulus Sphere_radius must be non-negative.");
+            SVMP_HERE, "Stimulus sphere Radius must be non-negative.");
       }
 
       lDmn.cep.Istim.sphere_defined = true;

--- a/Code/Source/solver/read_files.cpp
+++ b/Code/Source/solver/read_files.cpp
@@ -1085,6 +1085,9 @@ void read_cep_domain(Simulation* simulation, EquationParameters* eq_params, Doma
   lDmn.cep.Istim.Ts = 99999.0;
   lDmn.cep.Istim.CL = 99999.0;
   lDmn.cep.Istim.Td = 0.0;
+  lDmn.cep.Istim.box_defined = false;
+  lDmn.cep.Istim.sphere_defined = false;
+  lDmn.cep.Istim.sphere_radius = 0.0;
 
   if (domain_params->stimulus.defined()) { 
     auto& stimulus_params = domain_params->stimulus;
@@ -1129,6 +1132,34 @@ void read_cep_domain(Simulation* simulation, EquationParameters* eq_params, Doma
 
         lDmn.cep.Istim.box_min(i) = box_min[i];
         lDmn.cep.Istim.box_max(i) = box_max[i];
+      }
+    }
+
+    const bool sphere_center_defined = stimulus_params.sphere_center.defined();
+    const bool sphere_radius_defined = stimulus_params.sphere_radius.defined();
+
+    if (sphere_center_defined != sphere_radius_defined) {
+      throw std::runtime_error("Both Sphere_center and Sphere_radius must be specified for a CEP stimulus sphere.");
+    }
+
+    if (sphere_center_defined && sphere_radius_defined) {
+      const auto& sphere_center = stimulus_params.sphere_center.value();
+      const double sphere_radius = stimulus_params.sphere_radius.value();
+
+      if (sphere_center.size() < static_cast<std::size_t>(simulation->com_mod.nsd)) {
+        throw std::runtime_error("Stimulus sphere center dimension is smaller than the simulation spatial dimension.");
+      }
+
+      if (sphere_radius < 0.0) {
+        throw std::runtime_error("Stimulus Sphere_radius must be non-negative.");
+      }
+
+      lDmn.cep.Istim.sphere_defined = true;
+      lDmn.cep.Istim.sphere_center.resize(sphere_center.size());
+      lDmn.cep.Istim.sphere_radius = sphere_radius;
+
+      for (int i = 0; i < static_cast<int>(sphere_center.size()); i++) {
+        lDmn.cep.Istim.sphere_center(i) = sphere_center[i];
       }
     }
   }


### PR DESCRIPTION
## Current situation

Related to #572.

This PR adds optional geometric filtering for CEP applied stimuli. A CEP stimulus can now be restricted using an axis-aligned box, a sphere, or both together.

When both box and sphere bounds are provided, the stimulus is applied only to nodes that satisfy both geometric restrictions, while still respecting the parent domain.

This PR also incorporates review feedback by grouping the new XML parameters under `Spatial_bounds` and refactoring the stimulus-specific logic into `stimType`.

## Release Notes

* Added optional spatial bounds for CEP stimuli:

  * `Spatial_bounds / Box / Minimum`
  * `Spatial_bounds / Box / Maximum`
  * `Spatial_bounds / Sphere / Center`
  * `Spatial_bounds / Sphere / Radius`
* Box and sphere bounds can be used independently or together.
* When box and sphere bounds are both provided, the applied stimulus region is their intersection.
* Refactored CEP stimulus evaluation so temporal activation, spatial filtering, and MPI distribution are handled by `stimType`.
* Replaced feature-related error paths with the svMultiPhysics exception infrastructure.

Example:

```xml
<Stimulus type="Istim" >
  <Amplitude> -35.714 </Amplitude>
  <Start_time> 0.0 </Start_time>
  <Duration> 2.0 </Duration>
  <Cycle_length> 10000.0 </Cycle_length>

  <Spatial_bounds>
    <Box>
      <Minimum> 0.20 0.20 0.20 </Minimum>
      <Maximum> 1.00 1.00 1.00 </Maximum>
    </Box>

    <Sphere>
      <Center> 0.55 0.75 0.75 </Center>
      <Radius> 0.50 </Radius>
    </Sphere>
  </Spatial_bounds>
</Stimulus>
```

## Documentation

The new XML structure is documented in the `StimulusParameters` example in `Parameters.h`.

## Testing

Successfully compiled on macOS.

Validated using a Niederer benchmark CEP case with several stimulus configurations:

* no stimulus
* no spatial bounds
* box-only bounds
* sphere-only bounds
* overlapping box+sphere bounds
* disjoint box+sphere bounds
* impossible box/sphere bounds

The expected logical comparisons passed in serial and with MPI using 2 processes. In particular, the disjoint box+sphere and impossible-bound cases matched the no-stimulus case, while valid bounded cases differed from the unbounded stimulus case.

Also ran a visual validation using a spherical stimulus with 4 MPI processes and confirmed that the activation was localized and propagated as expected.

## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).