### PR TITLE
Fix incorrect indices in assembling weak Dirichlet conditions for the fluid

### DIFF
--- a/Code/Source/solver/fluid.cpp
+++ b/Code/Source/solver/fluid.cpp
@@ -462,13 +462,13 @@ void bw_fluid_3d(ComMod& com_mod, const int eNoNw, const int eNoNq, const double
       double T1 = wl*Nq(a)*Nw(b);
 
       // dRc_a/du_b1
-      lK(12,a,b) = lK(13,a,b) - T1*nV(0);
+      lK(12, a, b) = lK(12, a, b) - T1 * nV(0);
 
       // dRc_a/du_b2
-      lK(13,a,b) = lK(14,a,b) - T1*nV(1);
+      lK(13, a, b) = lK(13, a, b) - T1 * nV(1);
 
       // dRc_a/du_b3
-      lK(14,a,b) = lK(15,a,b) - T1*nV(2);
+      lK(14, a, b) = lK(14, a, b) - T1 * nV(2);
     }
   }
 }

--- a/tests/cases/fluid/pipe_RCR_weak_dir_3d/result_002.vtu
+++ b/tests/cases/fluid/pipe_RCR_weak_dir_3d/result_002.vtu
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66a2e1011d84fc609cd9ebda87c81273e479157727ebf990cd3829323a33dff3
-size 640514
+oid sha256:27fe82bf5c20d05c51b3ec0ac9d13e2acf7def982384b98a7cb9c3f6d8cacab5
+size 632425


### PR DESCRIPTION
Fixes #583.

There was a mismatch in the indices used to fill the local tangent in `bw_fluid_3d`, for assembling weak Dirichlet conditions.

This PR fixes the indices mismatch.

There is one test that for this feature (`fluid/pipe_RCR_weak_dir_3d`), and its reference solution needed to be updated as a result of this change.

## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
